### PR TITLE
Removes unnecessary encoding when unhexlifying

### DIFF
--- a/common/cryptographer.py
+++ b/common/cryptographer.py
@@ -132,7 +132,7 @@ class Cryptographer:
 
         # Decrypt
         cipher = ChaCha20Poly1305(sk)
-        data = unhexlify(encrypted_blob.data.encode())
+        data = unhexlify(encrypted_blob.data)
 
         try:
             blob = cipher.decrypt(nonce=nonce, data=data, associated_data=None)
@@ -278,7 +278,7 @@ class Cryptographer:
             return False
 
         if isinstance(signature, str):
-            signature = unhexlify(signature.encode("utf-8"))
+            signature = unhexlify(signature)
 
         try:
             pk.verify(signature, message, ec.ECDSA(hashes.SHA256()))

--- a/pisa/inspector.py
+++ b/pisa/inspector.py
@@ -335,7 +335,7 @@ class Inspector:
             rcode = errors.APPOINTMENT_EMPTY_FIELD
             message = "empty signature received"
 
-        pk = Cryptographer.load_public_key_der(unhexlify(pk_der.encode("utf-8")))
+        pk = Cryptographer.load_public_key_der(unhexlify(pk_der))
         valid_sig = Cryptographer.verify(Cryptographer.signature_format(appointment), signature, pk)
 
         if not valid_sig:

--- a/pisa/utils/zmq_subscriber.py
+++ b/pisa/utils/zmq_subscriber.py
@@ -28,7 +28,7 @@ class ZMQSubscriber:
                 body = msg[1]
 
                 if topic == b"hashblock":
-                    block_hash = binascii.hexlify(body).decode("UTF-8")
+                    block_hash = binascii.hexlify(body).decode("utf-8")
                     block_queue.put(block_hash)
 
                     self.logger.info("New block received via ZMQ", block_hash=block_hash)


### PR DESCRIPTION
`binascii.unhexlify(x)` is equal to `binascii.unhexlify(x.encode())`