### PR TITLE
Stores last block on db on fresh bootstrap for Watcher and Responder

### DIFF
--- a/teos/responder.py
+++ b/teos/responder.py
@@ -259,6 +259,7 @@ class Responder:
         # Distinguish fresh bootstraps from bootstraps from db
         if self.last_known_block is None:
             self.last_known_block = self.block_processor.get_best_block_hash()
+            self.db_manager.store_last_block_hash_responder(self.last_known_block)
 
         while True:
             block_hash = self.block_queue.get()

--- a/teos/watcher.py
+++ b/teos/watcher.py
@@ -71,7 +71,7 @@ class Watcher:
         self.max_appointments = max_appointments
         self.expiry_delta = expiry_delta
         self.signing_key = Cryptographer.load_private_key_der(sk_der)
-        self.last_known_block = db_manager.load_last_block_hash_responder()
+        self.last_known_block = db_manager.load_last_block_hash_watcher()
 
     def awake(self):
         """Starts a new thread to monitor the blockchain for channel breaches"""


### PR DESCRIPTION
The last known block was not stored in the db for the `Watcher` and `Responder` on fresh bootstrap until a block was received. This caused problems if stopping the tower before hearing about a block, specially in testing.

Fixes #117

- Stores `last_known_block` in the db for both the `Watcher` and `Responder` on fresh bootstrap (before `do_watch` main loop)
- Adds `last_known_block` to `Watcher` to deal with forks in the future.

