### PR TITLE
Removes start and end time from the appointment data

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,10 +49,10 @@ for opt, arg in opts:
 ```
 
 ```python
-if rcode == 0:
-    rcode, message = self.check_start_time(start_time, block_height)
-if rcode == 0:
-    rcode, message = self.check_end_time(end_time, start_time, block_height)
+if appointment_data is None:
+    raise InspectionFailed(errors.APPOINTMENT_EMPTY_FIELD, "empty appointment received")
+elif not isinstance(appointment_data, dict):
+    raise InspectionFailed(errors.APPOINTMENT_WRONG_FIELD, "wrong appointment format")
 ```
 
 ## Dev Requirements

--- a/cli/README.md
+++ b/cli/README.md
@@ -44,8 +44,6 @@ This command is used to send appointments to the watchtower. Appointments **must
 
 	{ "tx": tx,
 	  "tx_id": tx_id,
-	  "start_time": s,
-	  "end_time": e,
 	  "to_self_delay": d }
 	
 `tx` **must** be the raw penalty transaction that will be encrypted before sent to the watchtower. `type(tx) = hex encoded str`
@@ -59,12 +57,6 @@ This command is used to send appointments to the watchtower. Appointments **must
 `d` is the time the watchtower would have to respond with the **penalty transaction** once the **dispute transaction** is seen in the blockchain. `d` must match with the `OP_CSV` specified in the dispute transaction. If the to\_self\_delay does not match the `OP_CSV`, the watchtower will try to respond with the penalty transaction anyway, but success is not guaranteed. `d` is measured in blocks and should be at least `20`. `type(d) = int`
 
 The API will return a `application/json` HTTP response code `200/OK` if the appointment is accepted, with the locator encoded in the response text, or a `400/Bad Request` if the appointment is rejected, with the rejection reason encoded in the response text. 
-
-### Alpha release restrictions
-The alpha release does not have authentication, payments nor rate limiting, therefore some self imposed restrictions apply:
-
-- `start_time` should be within the next 6 blocks `[current_time+1, current_time+6]`.
-- `end_time` cannot be bigger than (roughly) a month. That is `4320` blocks on top of `start_time`.
 
 
 #### Usage
@@ -103,9 +95,7 @@ if `-f, --file` **is** specified, then the command expects a path to a json file
 		"appointment":
 			{
 				"encrypted_blob": eb,
-				"end_time": e,
 				"locator": appointment_locator,
-				"start_time": s,
 				"status": "being_watched",
 				"to_self_delay": d
 			}
@@ -118,7 +108,6 @@ if `-f, --file` **is** specified, then the command expects a path to a json file
 		"status": "dispute_responded",
 		"appointment":
 			{
-				"appointment_end": e,
 				"dispute_txid": dispute_txid,
 				"locator": appointment_locator,
 				"penalty_rawtx": penalty_rawtx,
@@ -164,10 +153,10 @@ python teos_cli.py register
 2. Generate a new dummy appointment. **Note:** this appointment will never be fulfilled (it will eventually expire) since it does not correspond to a valid transaction. However it can be used to interact with the Eye of Satoshi's API.
 
     ```
-	echo '{"tx": "4615a58815475ab8145b6bb90b1268a0dbb02e344ddd483f45052bec1f15b1951c1ee7f070a0993da395a5ee92ea3a1c184b5ffdb2507164bf1f8c1364155d48bdbc882eee0868ca69864a807f213f538990ad16f56d7dfb28a18e69e3f31ae9adad229e3244073b7d643b4597ec88bf247b9f73f301b0f25ae8207b02b7709c271da98af19f1db276ac48ba64f099644af1ae2c90edb7def5e8589a1bb17cc72ac42ecf07dd29cff91823938fd0d772c2c92b7ab050f8837efd46197c9b2b3f", "tx_id": "0b9510d92a50c1d67c6f7fc5d47908d96b3eccdea093d89bcbaf05bcfebdd951", "start_time": 0, "end_time": 0, "to_self_delay": 20}' > dummy_appointment_data.json
+	echo '{"tx": "4615a58815475ab8145b6bb90b1268a0dbb02e344ddd483f45052bec1f15b1951c1ee7f070a0993da395a5ee92ea3a1c184b5ffdb2507164bf1f8c1364155d48bdbc882eee0868ca69864a807f213f538990ad16f56d7dfb28a18e69e3f31ae9adad229e3244073b7d643b4597ec88bf247b9f73f301b0f25ae8207b02b7709c271da98af19f1db276ac48ba64f099644af1ae2c90edb7def5e8589a1bb17cc72ac42ecf07dd29cff91823938fd0d772c2c92b7ab050f8837efd46197c9b2b3f", "tx_id": "0b9510d92a50c1d67c6f7fc5d47908d96b3eccdea093d89bcbaf05bcfebdd951", "to_self_delay": 20}' > dummy_appointment_data.json
     ```
 
-    That will create a json file that follows the appointment data structure filled with dummy data and store it in `dummy_appointment_data.json`. **Note**: You'll need to update the `start_time` and `end_time` to match valid block heights.
+    That will create a json file that follows the appointment data structure filled with dummy data and store it in `dummy_appointment_data.json`.
 
 3. Send the appointment to the tower API. Which will then start monitoring for matching transactions.
 

--- a/cli/teos_cli.py
+++ b/cli/teos_cli.py
@@ -263,7 +263,7 @@ def post_request(data, endpoint):
         return requests.post(url=endpoint, json=data, timeout=5)
 
     except Timeout:
-        message = "Can't connect to the Eye of Satoshi's API. Connection timeout"
+        message = "Cannot connect to the Eye of Satoshi's API. Connection timeout"
 
     except ConnectionError:
         message = "Cannot connect to the Eye of Satoshi's API. Server cannot be reached"

--- a/common/appointment.py
+++ b/common/appointment.py
@@ -25,14 +25,12 @@ class Appointment:
         """
         Builds an appointment from a dictionary.
 
-        This method is useful to load data from a database.
-
         Args:
             appointment_data (:obj:`dict`): a dictionary containing the following keys:
                 ``{locator, to_self_delay, encrypted_blob}``
 
         Returns:
-            :obj:`Appointment <teos.appointment.Appointment>`: An appointment initialized using the provided data.
+            :obj:`Appointment <common.appointment.Appointment>`: An appointment initialized using the provided data.
 
         Raises:
             ValueError: If one of the mandatory keys is missing in ``appointment_data``.
@@ -40,13 +38,13 @@ class Appointment:
 
         locator = appointment_data.get("locator")
         to_self_delay = appointment_data.get("to_self_delay")
-        encrypted_blob_data = appointment_data.get("encrypted_blob")
+        encrypted_blob = appointment_data.get("encrypted_blob")
 
-        if any(v is None for v in [locator, to_self_delay, encrypted_blob_data]):
+        if any(v is None for v in [locator, to_self_delay, encrypted_blob]):
             raise ValueError("Wrong appointment data, some fields are missing")
 
         else:
-            appointment = cls(locator, to_self_delay, encrypted_blob_data)
+            appointment = cls(locator, to_self_delay, encrypted_blob)
 
         return appointment
 
@@ -58,14 +56,7 @@ class Appointment:
             :obj:`dict`: A dictionary containing the appointment attributes.
         """
 
-        # ToDO: #3-improve-appointment-structure
-        appointment = {
-            "locator": self.locator,
-            "to_self_delay": self.to_self_delay,
-            "encrypted_blob": self.encrypted_blob,
-        }
-
-        return appointment
+        return self.__dict__
 
     def serialize(self):
         """

--- a/common/appointment.py
+++ b/common/appointment.py
@@ -9,18 +9,14 @@ class Appointment:
     Args:
         locator (:obj:`str`): A 16-byte hex-encoded value used by the tower to detect channel breaches. It serves as a
             trigger for the tower to decrypt and broadcast the penalty transaction.
-        start_time (:obj:`int`): The block height where the tower is hired to start watching for breaches.
-        end_time (:obj:`int`): The block height where the tower will stop watching for breaches.
         to_self_delay (:obj:`int`): The ``to_self_delay`` encoded in the ``csv`` of the ``to_remote`` output of the
             commitment transaction that this appointment is covering.
         encrypted_blob (:obj:`str`): An encrypted blob of data containing a penalty transaction. The tower will decrypt
             it and broadcast the penalty transaction upon seeing a breach on the blockchain.
     """
 
-    def __init__(self, locator, start_time, end_time, to_self_delay, encrypted_blob):
+    def __init__(self, locator, to_self_delay, encrypted_blob):
         self.locator = locator
-        self.start_time = start_time  # ToDo: #4-standardize-appointment-fields
-        self.end_time = end_time  # ToDo: #4-standardize-appointment-fields
         self.to_self_delay = to_self_delay
         self.encrypted_blob = encrypted_blob
 
@@ -33,7 +29,7 @@ class Appointment:
 
         Args:
             appointment_data (:obj:`dict`): a dictionary containing the following keys:
-                ``{locator, start_time, end_time, to_self_delay, encrypted_blob}``
+                ``{locator, to_self_delay, encrypted_blob}``
 
         Returns:
             :obj:`Appointment <teos.appointment.Appointment>`: An appointment initialized using the provided data.
@@ -43,16 +39,14 @@ class Appointment:
         """
 
         locator = appointment_data.get("locator")
-        start_time = appointment_data.get("start_time")  # ToDo: #4-standardize-appointment-fields
-        end_time = appointment_data.get("end_time")  # ToDo: #4-standardize-appointment-fields
         to_self_delay = appointment_data.get("to_self_delay")
         encrypted_blob_data = appointment_data.get("encrypted_blob")
 
-        if any(v is None for v in [locator, start_time, end_time, to_self_delay, encrypted_blob_data]):
+        if any(v is None for v in [locator, to_self_delay, encrypted_blob_data]):
             raise ValueError("Wrong appointment data, some fields are missing")
 
         else:
-            appointment = cls(locator, start_time, end_time, to_self_delay, encrypted_blob_data)
+            appointment = cls(locator, to_self_delay, encrypted_blob_data)
 
         return appointment
 
@@ -67,8 +61,6 @@ class Appointment:
         # ToDO: #3-improve-appointment-structure
         appointment = {
             "locator": self.locator,
-            "start_time": self.start_time,
-            "end_time": self.end_time,
             "to_self_delay": self.to_self_delay,
             "encrypted_blob": self.encrypted_blob,
         }
@@ -80,17 +72,11 @@ class Appointment:
         Serializes an appointment to be signed.
 
         The serialization follows the same ordering as the fields in the appointment:
-            locator:start_time:end_time:to_self_delay:encrypted_blob
+            locator:to_self_delay:encrypted_blob
 
         All values are big endian.
 
         Returns:
               :obj:`bytes`: The serialized data to be signed.
         """
-        return (
-            unhexlify(self.locator)
-            + struct.pack(">I", self.start_time)
-            + struct.pack(">I", self.end_time)
-            + struct.pack(">I", self.to_self_delay)
-            + unhexlify(self.encrypted_blob)
-        )
+        return unhexlify(self.locator) + struct.pack(">I", self.to_self_delay) + unhexlify(self.encrypted_blob)

--- a/common/constants.py
+++ b/common/constants.py
@@ -8,5 +8,8 @@ HTTP_BAD_REQUEST = 400
 HTTP_NOT_FOUND = 404
 HTTP_SERVICE_UNAVAILABLE = 503
 
+# LN general nomenclature
+IRREVOCABLY_RESOLVED = 100
+
 # Temporary constants, may be changed
 ENCRYPTED_BLOB_MAX_SIZE_HEX = 2 * 2048

--- a/teos/__init__.py
+++ b/teos/__init__.py
@@ -18,6 +18,7 @@ DEFAULT_CONF = {
     "FEED_PORT": {"value": 28332, "type": int},
     "MAX_APPOINTMENTS": {"value": 1000000, "type": int},
     "DEFAULT_SLOTS": {"value": 100, "type": int},
+    "DEFAULT_SUBSCRIPTION_DURATION": {"value": 4320, "type": int},
     "EXPIRY_DELTA": {"value": 6, "type": int},
     "MIN_TO_SELF_DELAY": {"value": 20, "type": int},
     "LOG_FILE": {"value": "teos.log", "type": str, "path": True},

--- a/teos/api.py
+++ b/teos/api.py
@@ -120,14 +120,14 @@ class API:
             logger.info("Received invalid register request", from_addr="{}".format(remote_addr))
             return jsonify({"error": str(e)}), HTTP_BAD_REQUEST
 
-        client_pk = request_data.get("public_key")
+        user_id = request_data.get("public_key")
 
-        if client_pk:
+        if user_id:
             try:
                 rcode = HTTP_OK
-                available_slots, subscription_expiry = self.watcher.gatekeeper.add_update_user(client_pk)
+                available_slots, subscription_expiry = self.watcher.gatekeeper.add_update_user(user_id)
                 response = {
-                    "public_key": client_pk,
+                    "public_key": user_id,
                     "available_slots": available_slots,
                     "subscription_expiry": subscription_expiry,
                 }
@@ -234,10 +234,10 @@ class API:
 
             message = "get appointment {}".format(locator).encode()
             signature = request_data.get("signature")
-            user_pk = self.watcher.gatekeeper.authenticate_user(message, signature)
+            user_id = self.watcher.gatekeeper.authenticate_user(message, signature)
 
             triggered_appointments = self.watcher.db_manager.load_all_triggered_flags()
-            uuid = hash_160("{}{}".format(locator, user_pk))
+            uuid = hash_160("{}{}".format(locator, user_id))
 
             # If the appointment has been triggered, it should be in the locator (default else just in case).
             if uuid in triggered_appointments:

--- a/teos/api.py
+++ b/teos/api.py
@@ -69,16 +69,13 @@ class API:
         inspector (:obj:`Inspector <teos.inspector.Inspector>`): an ``Inspector`` instance to check the correctness of
             the received appointment data.
         watcher (:obj:`Watcher <teos.watcher.Watcher>`): a ``Watcher`` instance to pass the requests to.
-        gatekeeper (:obj:`Watcher <teos.gatekeeper.Gatekeeper>`): a `Gatekeeper` instance in charge to control the user
-            access.
     """
 
-    def __init__(self, host, port, inspector, watcher, gatekeeper):
+    def __init__(self, host, port, inspector, watcher):
         self.host = host
         self.port = port
         self.inspector = inspector
         self.watcher = watcher
-        self.gatekeeper = gatekeeper
         self.app = app
 
         # Adds all the routes to the functions listed above.
@@ -124,7 +121,7 @@ class API:
         if client_pk:
             try:
                 rcode = HTTP_OK
-                available_slots, subscription_expiry = self.gatekeeper.add_update_user(client_pk)
+                available_slots, subscription_expiry = self.watcher.gatekeeper.add_update_user(client_pk)
                 response = {
                     "public_key": client_pk,
                     "available_slots": available_slots,
@@ -233,7 +230,7 @@ class API:
 
             message = "get appointment {}".format(locator).encode()
             signature = request_data.get("signature")
-            user_pk = self.gatekeeper.authenticate_user(message, signature)
+            user_pk = self.watcher.gatekeeper.authenticate_user(message, signature)
 
             triggered_appointments = self.watcher.db_manager.load_all_triggered_flags()
             uuid = hash_160("{}{}".format(locator, user_pk))

--- a/teos/api.py
+++ b/teos/api.py
@@ -10,6 +10,7 @@ from teos.gatekeeper import NotEnoughSlots, AuthenticationFailure
 
 from common.logger import Logger
 from common.cryptographer import hash_160
+from common.exceptions import InvalidParameter
 from common.constants import HTTP_OK, HTTP_BAD_REQUEST, HTTP_SERVICE_UNAVAILABLE, HTTP_NOT_FOUND
 
 
@@ -48,7 +49,7 @@ def get_request_data_json(request):
         :obj:`dict`: the dictionary parsed from the json request.
 
     Raises:
-        :obj:`TypeError`: if the request is not json encoded or it does not decodes to a dictionary.
+        :obj:`InvalidParameter`: if the request is not json encoded or it does not decodes to a dictionary.
     """
 
     if request.is_json:
@@ -56,9 +57,9 @@ def get_request_data_json(request):
         if isinstance(request_data, dict):
             return request_data
         else:
-            raise TypeError("Invalid request content")
+            raise InvalidParameter("Invalid request content")
     else:
-        raise TypeError("Request is not json encoded")
+        raise InvalidParameter("Request is not json encoded")
 
 
 class API:
@@ -112,7 +113,7 @@ class API:
         try:
             request_data = get_request_data_json(request)
 
-        except TypeError as e:
+        except InvalidParameter as e:
             logger.info("Received invalid register request", from_addr="{}".format(remote_addr))
             return abort(HTTP_BAD_REQUEST, e)
 
@@ -128,7 +129,7 @@ class API:
                     "subscription_expiry": subscription_expiry,
                 }
 
-            except ValueError as e:
+            except InvalidParameter as e:
                 rcode = HTTP_BAD_REQUEST
                 error = "Error {}: {}".format(errors.REGISTRATION_MISSING_FIELD, str(e))
                 response = {"error": error}
@@ -164,7 +165,7 @@ class API:
         try:
             request_data = get_request_data_json(request)
 
-        except TypeError as e:
+        except InvalidParameter as e:
             return abort(HTTP_BAD_REQUEST, e)
 
         try:
@@ -218,7 +219,7 @@ class API:
         try:
             request_data = get_request_data_json(request)
 
-        except TypeError as e:
+        except InvalidParameter as e:
             logger.info("Received invalid get_appointment request", from_addr="{}".format(remote_addr))
             return abort(HTTP_BAD_REQUEST, e)
 

--- a/teos/appointments_dbm.py
+++ b/teos/appointments_dbm.py
@@ -84,7 +84,7 @@ class AppointmentsDBM(DBManager):
             ``RESPONDER_LAST_BLOCK_KEY``).
 
         Returns:
-            :obj:`str` or :obj:`None`: A 16-byte hex-encoded str representing the last known block hash.
+            :obj:`str` or :obj:`None`: A 32-byte hex-encoded str representing the last known block hash.
 
             Returns ``None`` if the entry is not found.
         """
@@ -177,7 +177,7 @@ class AppointmentsDBM(DBManager):
 
         Args:
             uuid (:obj:`str`): the identifier of the appointment to be stored.
-            appointment (:obj:`dict`): an appointment encoded as dictionary.
+            appointment (:obj:`dict`): an appointment encoded as a dictionary.
 
         Returns:
             :obj:`bool`: True if the appointment was stored in the db. False otherwise.
@@ -202,7 +202,7 @@ class AppointmentsDBM(DBManager):
 
         Args:
             uuid (:obj:`str`): the identifier of the appointment to be stored.
-            tracker (:obj:`dict`): a tracker encoded as dictionary.
+            tracker (:obj:`dict`): a tracker encoded as a dictionary.
 
         Returns:
             :obj:`bool`: True if the tracker was stored in the db. False otherwise.
@@ -247,7 +247,7 @@ class AppointmentsDBM(DBManager):
 
     def create_append_locator_map(self, locator, uuid):
         """
-        Creates (or appends to if already exists) a ``locator:uuid`` map.
+        Creates a ``locator:uuid`` map.
 
         If the map already exists, the new ``uuid`` is appended to the existing ones (if it is not already there).
 
@@ -334,7 +334,7 @@ class AppointmentsDBM(DBManager):
 
     def batch_delete_watcher_appointments(self, uuids):
         """
-        Deletes an appointment from the database.
+        Deletes multiple appointments from the database.
 
         Args:
            uuids (:obj:`list`): a list of 16-byte hex-encoded strings identifying the appointments to be deleted.
@@ -367,7 +367,7 @@ class AppointmentsDBM(DBManager):
 
     def batch_delete_responder_trackers(self, uuids):
         """
-        Deletes an appointment from the database.
+        Deletes multiple trackers from the database.
 
         Args:
            uuids (:obj:`list`): a list of 16-byte hex-encoded strings identifying the trackers to be deleted.

--- a/teos/block_processor.py
+++ b/teos/block_processor.py
@@ -14,7 +14,7 @@ class BlockProcessor:
 
     Args:
         btc_connect_params (:obj:`dict`): a dictionary with the parameters to connect to bitcoind
-            (rpc user, rpc passwd, host and port)
+            (rpc user, rpc password, host and port)
     """
 
     def __init__(self, btc_connect_params):
@@ -22,10 +22,10 @@ class BlockProcessor:
 
     def get_block(self, block_hash):
         """
-        Gives a block given a block hash by querying ``bitcoind``.
+        Gets a block given a block hash by querying ``bitcoind``.
 
         Args:
-            block_hash (:obj:`str`): The block hash to be queried.
+            block_hash (:obj:`str`): the block hash to be queried.
 
         Returns:
             :obj:`dict` or :obj:`None`: A dictionary containing the requested block data if the block is found.
@@ -44,7 +44,7 @@ class BlockProcessor:
 
     def get_best_block_hash(self):
         """
-        Returns the hash of the current best chain tip.
+        Gets the hash of the current best chain tip.
 
         Returns:
             :obj:`str` or :obj:`None`: The hash of the block if it can be found.
@@ -63,10 +63,10 @@ class BlockProcessor:
 
     def get_block_count(self):
         """
-        Returns the block height of the best chain.
+        Gets the block count of the best chain.
 
         Returns:
-            :obj:`int` or :obj:`None`: The block height if it can be computed.
+            :obj:`int` or :obj:`None`: The count of the best chain if it can be computed.
 
             Returns ``None`` otherwise (not even sure this can actually happen).
         """
@@ -86,7 +86,7 @@ class BlockProcessor:
         associated metadata given by ``bitcoind`` (e.g. confirmation count).
 
         Args:
-            raw_tx (:obj:`str`): The hex representation of the transaction.
+            raw_tx (:obj:`str`): the hex representation of the transaction.
 
         Returns:
             :obj:`dict` or :obj:`None`: The decoding of the given ``raw_tx`` if the transaction is well formatted.
@@ -133,7 +133,7 @@ class BlockProcessor:
 
     def get_missed_blocks(self, last_know_block_hash):
         """
-        Compute the blocks between the current best chain tip and a given block hash (``last_know_block_hash``).
+        Gets the blocks between the current best chain tip and a given block hash (``last_know_block_hash``).
 
         This method is used to fetch all the missed information when recovering from a crash.
 
@@ -158,7 +158,7 @@ class BlockProcessor:
 
     def is_block_in_best_chain(self, block_hash):
         """
-        Checks whether or not a given block is on the best chain. Blocks are identified by block_hash.
+        Checks whether a given block is on the best chain or not. Blocks are identified by block_hash.
 
         A block that is not in the best chain will either not exists (block = None) or have a confirmation count of
         -1 (implying that the block was forked out or the chain never grew from that one).

--- a/teos/builder.py
+++ b/teos/builder.py
@@ -1,13 +1,13 @@
 class Builder:
     """
-    The :class:`Builder` class is in charge of reconstructing data loaded from the database and build the data
-    structures of the :obj:`Watcher <teos.watcher.Watcher>` and the :obj:`Responder <teos.responder.Responder>`.
+    The :class:`Builder` class is in charge of reconstructing data loaded from the appointments database and build the
+    data structures of the :obj:`Watcher <teos.watcher.Watcher>` and the :obj:`Responder <teos.responder.Responder>`.
     """
 
     @staticmethod
     def build_appointments(appointments_data):
         """
-        Builds an appointments dictionary (``uuid: ExtendedAppointment``) and a locator_uuid_map (``locator: uuid``)
+        Builds an appointments dictionary (``uuid:ExtendedAppointment``) and a locator_uuid_map (``locator:uuid``)
         given a dictionary of appointments from the database.
 
         Args:
@@ -43,7 +43,7 @@ class Builder:
     @staticmethod
     def build_trackers(tracker_data):
         """
-        Builds a tracker dictionary (``uuid: TransactionTracker``) and a tx_tracker_map (``penalty_txid: uuid``) given
+        Builds a tracker dictionary (``uuid:TransactionTracker``) and a tx_tracker_map (``penalty_txid:uuid``) given
         a dictionary of trackers from the database.
 
         Args:
@@ -85,8 +85,8 @@ class Builder:
         :mod:`Responder <teos.responder.Responder>` using backed up data.
 
         Args:
-            block_queue (:obj:`Queue`): a ``Queue``
-            missed_blocks (:obj:`list`): list of block hashes missed by the Watchtower (do to a crash or shutdown).
+            block_queue (:obj:`Queue`): a ``Queue``.
+            missed_blocks (:obj:`list`): list of block hashes missed by the Watchtower (due to a crash or shutdown).
 
         Returns:
             :obj:`Queue`: A ``Queue`` containing all the missed blocks hashes.

--- a/teos/builder.py
+++ b/teos/builder.py
@@ -1,3 +1,7 @@
+from teos.responder import TransactionTracker
+from teos.extended_appointment import ExtendedAppointment
+
+
 class Builder:
     """
     The :class:`Builder` class is in charge of reconstructing data loaded from the appointments database and build the
@@ -26,17 +30,14 @@ class Builder:
         locator_uuid_map = {}
 
         for uuid, data in appointments_data.items():
-            appointments[uuid] = {
-                "locator": data.get("locator"),
-                "user_id": data.get("user_id"),
-                "size": len(data.get("encrypted_blob")),
-            }
+            appointment = ExtendedAppointment.from_dict(data)
+            appointments[uuid] = appointment.get_summary()
 
-            if data.get("locator") in locator_uuid_map:
-                locator_uuid_map[data.get("locator")].append(uuid)
+            if appointment.locator in locator_uuid_map:
+                locator_uuid_map[appointment.locator].append(uuid)
 
             else:
-                locator_uuid_map[data.get("locator")] = [uuid]
+                locator_uuid_map[appointment.locator] = [uuid]
 
         return appointments, locator_uuid_map
 
@@ -64,17 +65,14 @@ class Builder:
         tx_tracker_map = {}
 
         for uuid, data in tracker_data.items():
-            trackers[uuid] = {
-                "penalty_txid": data.get("penalty_txid"),
-                "locator": data.get("locator"),
-                "user_id": data.get("user_id"),
-            }
+            tracker = TransactionTracker.from_dict(data)
+            trackers[uuid] = tracker.get_summary()
 
-            if data.get("penalty_txid") in tx_tracker_map:
-                tx_tracker_map[data.get("penalty_txid")].append(uuid)
+            if tracker.penalty_txid in tx_tracker_map:
+                tx_tracker_map[tracker.penalty_txid].append(uuid)
 
             else:
-                tx_tracker_map[data.get("penalty_txid")] = [uuid]
+                tx_tracker_map[tracker.penalty_txid] = [uuid]
 
         return trackers, tx_tracker_map
 

--- a/teos/builder.py
+++ b/teos/builder.py
@@ -7,19 +7,19 @@ class Builder:
     @staticmethod
     def build_appointments(appointments_data):
         """
-        Builds an appointments dictionary (``uuid: Appointment``) and a locator_uuid_map (``locator: uuid``) given a
-        dictionary of appointments from the database.
+        Builds an appointments dictionary (``uuid: ExtendedAppointment``) and a locator_uuid_map (``locator: uuid``)
+        given a dictionary of appointments from the database.
 
         Args:
             appointments_data (:obj:`dict`): a dictionary of dictionaries representing all the
                 :obj:`Watcher <teos.watcher.Watcher>` appointments stored in the database. The structure is as follows:
 
-                    ``{uuid: {locator: str, start_time: int, ...}, uuid: {locator:...}}``
+                    ``{uuid: {locator: str, ...}, uuid: {locator:...}}``
 
         Returns:
             :obj:`tuple`: A tuple with two dictionaries. ``appointments`` containing the appointment information in
-            :obj:`Appointment <teos.appointment.Appointment>` objects and ``locator_uuid_map`` containing a map of
-            appointment (``uuid:locator``).
+            :obj:`ExtendedAppointment <teos.extended_appointment.ExtendedAppointment>` objects and ``locator_uuid_map``
+            containing a map of appointment (``uuid:locator``).
         """
 
         appointments = {}
@@ -28,7 +28,7 @@ class Builder:
         for uuid, data in appointments_data.items():
             appointments[uuid] = {
                 "locator": data.get("locator"),
-                "end_time": data.get("end_time"),
+                "user_id": data.get("user_id"),
                 "size": len(data.get("encrypted_blob")),
             }
 
@@ -67,7 +67,7 @@ class Builder:
             trackers[uuid] = {
                 "penalty_txid": data.get("penalty_txid"),
                 "locator": data.get("locator"),
-                "appointment_end": data.get("appointment_end"),
+                "user_id": data.get("user_id"),
             }
 
             if data.get("penalty_txid") in tx_tracker_map:

--- a/teos/chain_monitor.py
+++ b/teos/chain_monitor.py
@@ -20,14 +20,14 @@ class ChainMonitor:
     Args:
         watcher_queue (:obj:`Queue`): the queue to be used to send blocks hashes to the ``Watcher``.
         responder_queue (:obj:`Queue`): the queue to be used to send blocks hashes to the ``Responder``.
-        block_processor (:obj:`BlockProcessor <teos.block_processor.BlockProcessor>`): a blockProcessor instance.
+        block_processor (:obj:`BlockProcessor <teos.block_processor.BlockProcessor>`): a ``BlockProcessor`` instance.
         bitcoind_feed_params (:obj:`dict`): a dict with the feed (ZMQ) connection parameters.
 
     Attributes:
         best_tip (:obj:`str`): a block hash representing the current best tip.
         last_tips (:obj:`list`): a list of last chain tips. Used as a sliding window to avoid notifying about old tips.
         terminate (:obj:`bool`): a flag to signal the termination of the :class:`ChainMonitor` (shutdown the tower).
-        check_tip (:obj:`Event`): an event that's triggered at fixed time intervals and controls the polling thread.
+        check_tip (:obj:`Event`): an event that is triggered at fixed time intervals and controls the polling thread.
         lock (:obj:`Condition`): a lock used to protect concurrent access to the queues and ``best_tip`` by the zmq and
             polling threads.
         zmqSubSocket (:obj:`socket`): a socket to connect to ``bitcoind`` via ``zmq``.

--- a/teos/cleaner.py
+++ b/teos/cleaner.py
@@ -189,10 +189,10 @@ class Cleaner:
         Args:
             trackers (:obj:`dict`): a dictionary containing all the :obj:`Responder <teos.responder.Responder>`
                 trackers.
+            height (:obj:`int`): the block height at which the trackers were completed.
             tx_tracker_map (:obj:`dict`): a ``penalty_txid:uuid`` map for the :obj:`Responder
                 <teos.responder.Responder>` trackers.
-            completed_trackers (:obj:`dict`): a dict of completed trackers to be deleted (uuid:confirmations).
-            height (:obj:`int`): the block height at which the trackers were completed.
+            completed_trackers (:obj:`dict`): a dict of completed/expired trackers to be deleted (uuid:confirmations).
             db_manager (:obj:`AppointmentsDBM <teos.appointments_dbm.AppointmentsDBM>`): a ``AppointmentsDBM`` instance
                 to interact with the database.
             expired (:obj:`bool`): whether the trackers have expired or not. Defaults to False.

--- a/teos/cleaner.py
+++ b/teos/cleaner.py
@@ -87,7 +87,7 @@ class Cleaner:
     @staticmethod
     def delete_expired_appointments(expired_appointments, appointments, locator_uuid_map, db_manager):
         """
-        Deletes appointments which ``end_time`` has been reached (with no trigger) both from memory
+        Deletes appointments which ``expiry`` has been reached (with no trigger) both from memory
         (:obj:`Watcher <teos.watcher.Watcher>`) and disk.
 
         Args:
@@ -181,10 +181,10 @@ class Cleaner:
             db_manager.create_triggered_appointment_flag(uuid)
 
     @staticmethod
-    def delete_completed_trackers(completed_trackers, height, trackers, tx_tracker_map, db_manager):
+    def delete_trackers(completed_trackers, height, trackers, tx_tracker_map, db_manager, expired=False):
         """
-        Deletes a completed tracker both from memory (:obj:`Responder <teos.responder.Responder>`) and disk (from the
-        Responder's and Watcher's databases).
+        Deletes completed/expired trackers both from memory (:obj:`Responder <teos.responder.Responder>`) and disk
+        (from the Responder's and Watcher's databases).
 
         Args:
             trackers (:obj:`dict`): a dictionary containing all the :obj:`Responder <teos.responder.Responder>`
@@ -195,17 +195,23 @@ class Cleaner:
             height (:obj:`int`): the block height at which the trackers were completed.
             db_manager (:obj:`AppointmentsDBM <teos.appointments_dbm.AppointmentsDBM>`): a ``AppointmentsDBM`` instance
                 to interact with the database.
+            expired (:obj:`bool`): whether the trackers have expired or not. Defaults to False.
         """
 
         locator_maps_to_update = {}
 
-        for uuid, confirmations in completed_trackers.items():
-            logger.info(
-                "Appointment completed. Appointment ended after reaching enough confirmations",
-                uuid=uuid,
-                height=height,
-                confirmations=confirmations,
-            )
+        for uuid in completed_trackers:
+
+            if expired:
+                logger.info(
+                    "Appointment couldn't be completed. Expiry reached but penalty didn't make it to the chain",
+                    uuid=uuid,
+                    height=height,
+                )
+            else:
+                logger.info(
+                    "Appointment completed. Penalty transaction was irrevocably confirmed", uuid=uuid, height=height
+                )
 
             penalty_txid = trackers[uuid].get("penalty_txid")
             locator = trackers[uuid].get("locator")
@@ -229,6 +235,6 @@ class Cleaner:
             Cleaner.update_delete_db_locator_map(uuids, locator, db_manager)
 
         # Delete appointment from the db (from watchers's and responder's db) and remove flag
-        db_manager.batch_delete_responder_trackers(list(completed_trackers.keys()))
-        db_manager.batch_delete_watcher_appointments(list(completed_trackers.keys()))
-        db_manager.batch_delete_triggered_appointment_flag(list(completed_trackers.keys()))
+        db_manager.batch_delete_responder_trackers(completed_trackers)
+        db_manager.batch_delete_watcher_appointments(completed_trackers)
+        db_manager.batch_delete_triggered_appointment_flag(completed_trackers)

--- a/teos/extended_appointment.py
+++ b/teos/extended_appointment.py
@@ -13,7 +13,7 @@ class ExtendedAppointment(Appointment):
         Returns:
             :obj:`dict`: the appointment summary.
         """
-        return {"locator": self.locator, "user_id": self.user_id, "size": len(self.encrypted_blob)}
+        return {"locator": self.locator, "user_id": self.user_id}
 
     @classmethod
     def from_dict(cls, appointment_data):

--- a/teos/extended_appointment.py
+++ b/teos/extended_appointment.py
@@ -15,7 +15,7 @@ class ExtendedAppointment(Appointment):
 
         Args:
             appointment_data (:obj:`dict`): a dictionary containing the following keys:
-                ``{locator, to_self_delay, encrypted_blob, expiry}``
+                ``{locator, to_self_delay, encrypted_blob, user_id}``
 
         Returns:
             :obj:`ExtendedAppointment <teos.extended_appointment.ExtendedAppointment>`: An appointment initialized

--- a/teos/extended_appointment.py
+++ b/teos/extended_appointment.py
@@ -1,0 +1,37 @@
+from common.appointment import Appointment
+
+
+class ExtendedAppointment(Appointment):
+    def __init__(self, locator, to_self_delay, encrypted_blob, user_id):
+        super().__init__(locator, to_self_delay, encrypted_blob)
+        self.user_id = user_id
+
+    @classmethod
+    def from_dict(cls, appointment_data):
+        """
+        Builds an appointment from a dictionary.
+
+        This method is useful to load data from a database.
+
+        Args:
+            appointment_data (:obj:`dict`): a dictionary containing the following keys:
+                ``{locator, to_self_delay, encrypted_blob, expiry}``
+
+        Returns:
+            :obj:`ExtendedAppointment <teos.extended_appointment.ExtendedAppointment>`: An appointment initialized
+            using the provided data.
+
+        Raises:
+            ValueError: If one of the mandatory keys is missing in ``appointment_data``.
+        """
+
+        appointment = Appointment.from_dict(appointment_data)
+        user_id = appointment_data.get("user_id")
+
+        if not user_id:
+            raise ValueError("Wrong appointment data, user_id is missing")
+
+        else:
+            appointment = cls(appointment.locator, appointment.to_self_delay, appointment.encrypted_blob, user_id)
+
+        return appointment

--- a/teos/extended_appointment.py
+++ b/teos/extended_appointment.py
@@ -6,6 +6,15 @@ class ExtendedAppointment(Appointment):
         super().__init__(locator, to_self_delay, encrypted_blob)
         self.user_id = user_id
 
+    def get_summary(self):
+        """
+        Returns the summary of an appointment, consisting on the locator, the user_id and the appointment size.
+
+        Returns:
+            :obj:`dict`: the appointment summary.
+        """
+        return {"locator": self.locator, "user_id": self.user_id, "size": len(self.encrypted_blob)}
+
     @classmethod
     def from_dict(cls, appointment_data):
         """

--- a/teos/gatekeeper.py
+++ b/teos/gatekeeper.py
@@ -190,8 +190,9 @@ class Gatekeeper:
             :obj:`list`: a list of appointment uuids that will expire at ``block_height``.
         """
         expired_appointments = []
-        for user_id, user_info in self.registered_users.items():
-            if block_height == user_info.subscription_expiry + self.expiry_delta:
-                expired_appointments.extend(user_info.appointments)
+        # Avoiding dictionary changed size during iteration
+        for user_id in list(self.registered_users.keys()):
+            if block_height == self.registered_users[user_id].subscription_expiry + self.expiry_delta:
+                expired_appointments.extend(self.registered_users[user_id].appointments)
 
         return expired_appointments

--- a/teos/gatekeeper.py
+++ b/teos/gatekeeper.py
@@ -53,7 +53,15 @@ class Gatekeeper:
     perform actions.
 
     Attributes:
+        default_slots (:obj:`int`): the number of slots assigned to a user subscription.
+        default_subscription_duration (:obj:`int`): the expiry assigned to a user subscription.
+        expiry_delta (:obj:`int`): the grace period given to the user to renew their subscription.
+        block_processor (:obj:`BlockProcessor <teos.block_processor.BlockProcessor>`): a ``BlockProcessor`` instance to
+            get block from bitcoind.
+        user_db (:obj:`UserDBM <teos.user_dbm.UserDBM>`): a ``UserDBM`` instance to interact with the database.
         registered_users (:obj:`dict`): a map of user_pk:UserInfo.
+        lock (:obj:`Lock`): a Threading.Lock object to lock access to the Gatekeeper on updates.
+
     """
 
     def __init__(self, user_db, block_processor, default_slots, default_subscription_duration, expiry_delta):
@@ -75,12 +83,15 @@ class Gatekeeper:
             user_pk(:obj:`str`): the public key that identifies the user (33-bytes hex str).
 
         Returns:
-            :obj:`tuple`: a tuple with the number of available slots in the user subscription and the subscription end
-            time (in absolute block height).
+            :obj:`tuple`: a tuple with the number of available slots in the user subscription and the subscription
+            expiry (in absolute block height).
+
+        Raises:
+            :obj:`InvalidParameter`: if the user_pk does not match the expected format.
         """
 
         if not is_compressed_pk(user_pk):
-            raise ValueError("Provided public key does not match expected format (33-byte hex string)")
+            raise InvalidParameter("Provided public key does not match expected format (33-byte hex string)")
 
         if user_pk not in self.registered_users:
             self.registered_users[user_pk] = UserInfo(
@@ -125,11 +136,33 @@ class Gatekeeper:
             raise AuthenticationFailure("Wrong message or signature.")
 
     def update_available_slots(self, user_id, new_appointment, old_appointment=None):
+        """
+        Updates (add/removes) slots from a user subscription.
+
+        Slots are removed if a new subscription is given, or an update is given with a new subscription bigger than the
+        old one.
+
+        Slots are added if an update is given but the new appointment is smaller than the old one.
+
+        Args:
+            user_id(:obj:`str`): the public key that identifies the user (33-bytes hex str).
+            new_appointment (:obj:`ExtendedAppointment <teos.extended_appointment.ExtendedAppointment>`): the new
+                appointment the user is requesting to add.
+            old_appointment (:obj:`ExtendedAppointment <teos.extended_appointment.ExtendedAppointment>`): the old
+                appointment the user wants to replace. Optional.
+
+        Returns:
+            :obj:`int`: the number of remaining appointment slots.
+
+        Raises:
+            :obj:`NotEnoughSlots`: If the user does not have enough slots to fill.
+        """
+
         self.lock.acquire()
         if old_appointment:
             # For updates the difference between the existing appointment and the update is computed.
-            used_slots = ceil(new_appointment.get("size") / ENCRYPTED_BLOB_MAX_SIZE_HEX)
-            required_slots = ceil(old_appointment.get("size") / ENCRYPTED_BLOB_MAX_SIZE_HEX) - used_slots
+            used_slots = ceil(old_appointment.get("size") / ENCRYPTED_BLOB_MAX_SIZE_HEX)
+            required_slots = ceil(new_appointment.get("size") / ENCRYPTED_BLOB_MAX_SIZE_HEX) - used_slots
         else:
             # For regular appointments 1 slot is reserved per ENCRYPTED_BLOB_MAX_SIZE_HEX block.
             required_slots = ceil(new_appointment.get("size") / ENCRYPTED_BLOB_MAX_SIZE_HEX)
@@ -145,8 +178,19 @@ class Gatekeeper:
         self.lock.release()
         return self.registered_users.get(user_id).available_slots
 
-    def get_expiring_appointments(self, block_height):
-        expiring_appointments = []
+    def get_expired_appointments(self, block_height):
+        """
+        Gets a list of appointments that are expiring at a given block height.
+
+        Args:
+            block_height: the block height that wants to be checked.
+
+        Returns:
+            :obj:`list`: a list of appointment uuids that will expire at ``block_height``.
+        """
+        expired_appointments = []
         for user_id, user_info in self.registered_users.items():
-            if block_height > user_info.subscription_expiry + self.expiry_delta:
-                expiring_appointments.extend(user_info.appointments)
+            if block_height == user_info.subscription_expiry + self.expiry_delta:
+                expired_appointments.extend(user_info.appointments)
+
+        return expired_appointments

--- a/teos/gatekeeper.py
+++ b/teos/gatekeeper.py
@@ -27,6 +27,7 @@ class UserInfo:
         self.available_slots = available_slots
         self.subscription_expiry = subscription_expiry
 
+        # FIXME: this list is currently never wiped
         if not appointments:
             self.appointments = []
         else:
@@ -139,17 +140,17 @@ class Gatekeeper:
         """
         Updates (add/removes) slots from a user subscription.
 
-        Slots are removed if a new subscription is given, or an update is given with a new subscription bigger than the
+        Slots are removed if a new appointment is given, or an update is given with an appointment bigger than the
         old one.
 
         Slots are added if an update is given but the new appointment is smaller than the old one.
 
         Args:
             user_id(:obj:`str`): the public key that identifies the user (33-bytes hex str).
-            new_appointment (:obj:`ExtendedAppointment <teos.extended_appointment.ExtendedAppointment>`): the new
-                appointment the user is requesting to add.
-            old_appointment (:obj:`ExtendedAppointment <teos.extended_appointment.ExtendedAppointment>`): the old
-                appointment the user wants to replace. Optional.
+            new_appointment (:obj:`dict`): the summary of new appointment the user is requesting
+                to add.
+            old_appointment (:obj:`dict`): the summary old appointment the user wants to replace.
+                Optional.
 
         Returns:
             :obj:`int`: the number of remaining appointment slots.
@@ -180,7 +181,7 @@ class Gatekeeper:
 
     def get_expired_appointments(self, block_height):
         """
-        Gets a list of appointments that are expiring at a given block height.
+        Gets a list of appointments that expire at a given block height.
 
         Args:
             block_height: the block height that wants to be checked.

--- a/teos/inspector.py
+++ b/teos/inspector.py
@@ -47,7 +47,6 @@ class Inspector:
         Args:
             appointment_data (:obj:`dict`): a dictionary containing the appointment data.
 
-
         Returns:
             :obj:`Extended <teos.extended_appointment.ExtendedAppointment>`: An appointment initialized with
             the provided data.
@@ -141,7 +140,6 @@ class Inspector:
                 ),
             )
 
-    # ToDo: #6-define-checks-encrypted-blob
     @staticmethod
     def check_blob(encrypted_blob):
         """

--- a/teos/inspector.py
+++ b/teos/inspector.py
@@ -3,9 +3,9 @@ import re
 from common.logger import Logger
 from common.tools import is_locator
 from common.constants import LOCATOR_LEN_HEX
-from common.appointment import Appointment
 
 from teos import errors, LOG_PREFIX
+from teos.extended_appointment import ExtendedAppointment
 
 logger = Logger(actor="Inspector", log_name_prefix=LOG_PREFIX)
 
@@ -49,7 +49,8 @@ class Inspector:
 
 
         Returns:
-            :obj:`Appointment <teos.appointment.Appointment>`: An appointment initialized with the provided data.
+            :obj:`Extended <teos.extended_appointment.ExtendedAppointment>`: An appointment initialized with
+            the provided data.
 
         Raises:
            :obj:`InspectionFailed`: if any of the fields is wrong.
@@ -68,7 +69,13 @@ class Inspector:
         self.check_to_self_delay(appointment_data.get("to_self_delay"))
         self.check_blob(appointment_data.get("encrypted_blob"))
 
-        return Appointment.from_dict(appointment_data)
+        # Set user_id to None since we still don't know it, it'll be set by the API after querying the gatekeeper
+        return ExtendedAppointment(
+            appointment_data.get("locator"),
+            appointment_data.get("to_self_delay"),
+            appointment_data.get("encrypted_blob"),
+            user_id=None,
+        )
 
     @staticmethod
     def check_locator(locator):

--- a/teos/inspector.py
+++ b/teos/inspector.py
@@ -65,8 +65,6 @@ class Inspector:
             raise InspectionFailed(errors.UNKNOWN_JSON_RPC_EXCEPTION, "unexpected error occurred")
 
         self.check_locator(appointment_data.get("locator"))
-        self.check_start_time(appointment_data.get("start_time"), block_height)
-        self.check_end_time(appointment_data.get("end_time"), appointment_data.get("start_time"), block_height)
         self.check_to_self_delay(appointment_data.get("to_self_delay"))
         self.check_blob(appointment_data.get("encrypted_blob"))
 
@@ -99,87 +97,6 @@ class Inspector:
 
         elif not is_locator(locator):
             raise InspectionFailed(errors.APPOINTMENT_WRONG_FIELD_FORMAT, "wrong locator format ({})".format(locator))
-
-    @staticmethod
-    def check_start_time(start_time, block_height):
-        """
-        Checks if the provided ``start_time`` is correct.
-
-        Start times must be ahead the current best chain tip.
-
-        Args:
-            start_time (:obj:`int`): the block height at which the tower is requested to start watching for breaches.
-            block_height (:obj:`int`): the chain height.
-
-        Raises:
-           :obj:`InspectionFailed`: if any of the fields is wrong.
-        """
-
-        if start_time is None:
-            raise InspectionFailed(errors.APPOINTMENT_EMPTY_FIELD, "empty start_time received")
-
-        elif type(start_time) != int:
-            raise InspectionFailed(
-                errors.APPOINTMENT_WRONG_FIELD_TYPE, "wrong start_time data type ({})".format(type(start_time))
-            )
-
-        elif start_time < block_height:
-            raise InspectionFailed(errors.APPOINTMENT_FIELD_TOO_SMALL, "start_time is in the past")
-
-        elif start_time == block_height:
-            raise InspectionFailed(
-                errors.APPOINTMENT_FIELD_TOO_SMALL,
-                "start_time is too close to current height. Accepted times are: [current_height+1, current_height+6]",
-            )
-
-        elif start_time > block_height + 6:
-            raise InspectionFailed(
-                errors.APPOINTMENT_FIELD_TOO_BIG,
-                "start_time is too far in the future. Accepted start times are up to 6 blocks in the future",
-            )
-
-    @staticmethod
-    def check_end_time(end_time, start_time, block_height):
-        """
-        Checks if the provided ``end_time`` is correct.
-
-        End times must be ahead both the ``start_time`` and the current best chain tip.
-
-        Args:
-            end_time (:obj:`int`): the block height at which the tower is requested to stop watching for breaches.
-            start_time (:obj:`int`): the block height at which the tower is requested to start watching for breaches.
-            block_height (:obj:`int`): the chain height.
-
-        Raises:
-           :obj:`InspectionFailed`: if any of the fields is wrong.
-        """
-
-        # TODO: What's too close to the current height is not properly defined. Right now any appointment that ends in
-        #       the future will be accepted (even if it's only one block away).
-
-        if end_time is None:
-            raise InspectionFailed(errors.APPOINTMENT_EMPTY_FIELD, "empty end_time received")
-
-        elif type(end_time) != int:
-            raise InspectionFailed(
-                errors.APPOINTMENT_WRONG_FIELD_TYPE, "wrong end_time data type ({})".format(type(end_time))
-            )
-
-        elif end_time > block_height + BLOCKS_IN_A_MONTH:  # 4320 = roughly a month in blocks
-            raise InspectionFailed(
-                errors.APPOINTMENT_FIELD_TOO_BIG, "end_time should be within the next month (<= current_height + 4320)"
-            )
-        elif start_time > end_time:
-            raise InspectionFailed(errors.APPOINTMENT_FIELD_TOO_SMALL, "end_time is smaller than start_time")
-
-        elif start_time == end_time:
-            raise InspectionFailed(errors.APPOINTMENT_FIELD_TOO_SMALL, "end_time is equal to start_time")
-
-        elif block_height > end_time:
-            raise InspectionFailed(errors.APPOINTMENT_FIELD_TOO_SMALL, "end_time is in the past")
-
-        elif block_height == end_time:
-            raise InspectionFailed(errors.APPOINTMENT_FIELD_TOO_SMALL, "end_time is too close to current height")
 
     def check_to_self_delay(self, to_self_delay):
         """

--- a/teos/responder.py
+++ b/teos/responder.py
@@ -2,8 +2,10 @@ from queue import Queue
 from threading import Thread
 
 from teos import LOG_PREFIX
-from common.logger import Logger
 from teos.cleaner import Cleaner
+
+from common.logger import Logger
+from common.constants import IRREVOCABLY_RESOLVED
 
 CONFIRMATIONS_BEFORE_RETRY = 6
 MIN_CONFIRMATIONS = 6
@@ -26,16 +28,15 @@ class TransactionTracker:
         dispute_txid (:obj:`str`): the id of the transaction that created the channel breach and triggered the penalty.
         penalty_txid (:obj:`str`): the id of the transaction that was encrypted under ``dispute_txid``.
         penalty_rawtx (:obj:`str`): the raw transaction that was broadcast as a consequence of the channel breach.
-        appointment_end (:obj:`int`): the block at which the tower will stop monitoring the blockchain for this
-            appointment.
+        user_id(:obj:`str`): the public key that identifies the user (33-bytes hex str).
     """
 
-    def __init__(self, locator, dispute_txid, penalty_txid, penalty_rawtx, appointment_end):
+    def __init__(self, locator, dispute_txid, penalty_txid, penalty_rawtx, user_id):
         self.locator = locator
         self.dispute_txid = dispute_txid
         self.penalty_txid = penalty_txid
         self.penalty_rawtx = penalty_rawtx
-        self.appointment_end = appointment_end
+        self.user_id = user_id
 
     @classmethod
     def from_dict(cls, tx_tracker_data):
@@ -60,13 +61,13 @@ class TransactionTracker:
         dispute_txid = tx_tracker_data.get("dispute_txid")
         penalty_txid = tx_tracker_data.get("penalty_txid")
         penalty_rawtx = tx_tracker_data.get("penalty_rawtx")
-        appointment_end = tx_tracker_data.get("appointment_end")
+        user_id = tx_tracker_data.get("user_id")
 
-        if any(v is None for v in [locator, dispute_txid, penalty_txid, penalty_rawtx, appointment_end]):
+        if any(v is None for v in [locator, dispute_txid, penalty_txid, penalty_rawtx, user_id]):
             raise ValueError("Wrong transaction tracker data, some fields are missing")
 
         else:
-            tx_tracker = cls(locator, dispute_txid, penalty_txid, penalty_rawtx, appointment_end)
+            tx_tracker = cls(locator, dispute_txid, penalty_txid, penalty_rawtx, user_id)
 
         return tx_tracker
 
@@ -83,7 +84,7 @@ class TransactionTracker:
             "dispute_txid": self.dispute_txid,
             "penalty_txid": self.penalty_txid,
             "penalty_rawtx": self.penalty_rawtx,
-            "appointment_end": self.appointment_end,
+            "user_id": self.user_id,
         }
 
         return tx_tracker
@@ -104,7 +105,7 @@ class Responder:
 
     Attributes:
         trackers (:obj:`dict`): A dictionary containing the minimum information about the :obj:`TransactionTracker`
-            required by the :obj:`Responder` (``penalty_txid``, ``locator`` and ``end_time``).
+            required by the :obj:`Responder` (``penalty_txid``, ``locator`` and ``user_id``).
             Each entry is identified by a ``uuid``.
         tx_tracker_map (:obj:`dict`): A ``penalty_txid:uuid`` map used to allow the :obj:`Responder` to deal with
             several trackers triggered by the same ``penalty_txid``.
@@ -121,13 +122,14 @@ class Responder:
         last_known_block (:obj:`str`): the last block known by the ``Responder``.
     """
 
-    def __init__(self, db_manager, carrier, block_processor):
+    def __init__(self, db_manager, gatekeeper, carrier, block_processor):
         self.trackers = dict()
         self.tx_tracker_map = dict()
         self.unconfirmed_txs = []
         self.missed_confirmations = dict()
         self.block_queue = Queue()
         self.db_manager = db_manager
+        self.gatekeeper = gatekeeper
         self.carrier = carrier
         self.block_processor = block_processor
         self.last_known_block = db_manager.load_last_block_hash_responder()
@@ -169,7 +171,7 @@ class Responder:
 
         return synchronized
 
-    def handle_breach(self, uuid, locator, dispute_txid, penalty_txid, penalty_rawtx, appointment_end, block_hash):
+    def handle_breach(self, uuid, locator, dispute_txid, penalty_txid, penalty_rawtx, user_id, block_hash):
         """
         Requests the :obj:`Responder` to handle a channel breach. This is the entry point of the :obj:`Responder`.
 
@@ -179,8 +181,7 @@ class Responder:
             dispute_txid (:obj:`str`): the id of the transaction that created the channel breach.
             penalty_txid (:obj:`str`): the id of the decrypted transaction included in the appointment.
             penalty_rawtx (:obj:`str`): the raw transaction to be broadcast in response of the breach.
-            appointment_end (:obj:`int`): the block height at which the :obj:`Responder` will stop monitoring for this
-                penalty transaction.
+            user_id(:obj:`str`): the public key that identifies the user (33-bytes hex str).
             block_hash (:obj:`str`): the block hash at which the breach was seen (used to see if we are on sync).
 
         Returns:
@@ -191,9 +192,7 @@ class Responder:
         receipt = self.carrier.send_transaction(penalty_rawtx, penalty_txid)
 
         if receipt.delivered:
-            self.add_tracker(
-                uuid, locator, dispute_txid, penalty_txid, penalty_rawtx, appointment_end, receipt.confirmations
-            )
+            self.add_tracker(uuid, locator, dispute_txid, penalty_txid, penalty_rawtx, user_id, receipt.confirmations)
 
         else:
             # TODO: Add the missing reasons (e.g. RPC_VERIFY_REJECTED)
@@ -204,7 +203,7 @@ class Responder:
 
         return receipt
 
-    def add_tracker(self, uuid, locator, dispute_txid, penalty_txid, penalty_rawtx, appointment_end, confirmations=0):
+    def add_tracker(self, uuid, locator, dispute_txid, penalty_txid, penalty_rawtx, user_id, confirmations=0):
         """
         Creates a :obj:`TransactionTracker` after successfully broadcasting a ``penalty_tx``.
 
@@ -217,20 +216,15 @@ class Responder:
             dispute_txid (:obj:`str`): the id of the transaction that created the channel breach.
             penalty_txid (:obj:`str`): the id of the decrypted transaction included in the appointment.
             penalty_rawtx (:obj:`str`): the raw transaction to be broadcast.
-            appointment_end (:obj:`int`): the block height at which the :obj:`Responder` will stop monitoring for the
-                tracker.
+            user_id(:obj:`str`): the public key that identifies the user (33-bytes hex str).
             confirmations (:obj:`int`): the confirmation count of the ``penalty_tx``. In normal conditions it will be
                 zero, but if the transaction is already on the blockchain this won't be the case.
         """
 
-        tracker = TransactionTracker(locator, dispute_txid, penalty_txid, penalty_rawtx, appointment_end)
+        tracker = TransactionTracker(locator, dispute_txid, penalty_txid, penalty_rawtx, user_id)
 
-        # We only store the penalty_txid, locator and appointment_end in memory. The rest is dumped into the db.
-        self.trackers[uuid] = {
-            "penalty_txid": tracker.penalty_txid,
-            "locator": locator,
-            "appointment_end": appointment_end,
-        }
+        # We only store the penalty_txid, locator and user_id in memory. The rest is dumped into the db.
+        self.trackers[uuid] = {"penalty_txid": tracker.penalty_txid, "locator": locator, "user_id": user_id}
 
         if penalty_txid in self.tx_tracker_map:
             self.tx_tracker_map[penalty_txid].append(uuid)
@@ -244,9 +238,7 @@ class Responder:
 
         self.db_manager.store_responder_tracker(uuid, tracker.to_dict())
 
-        logger.info(
-            "New tracker added", dispute_txid=dispute_txid, penalty_txid=penalty_txid, appointment_end=appointment_end
-        )
+        logger.info("New tracker added", dispute_txid=dispute_txid, penalty_txid=penalty_txid, user_id=user_id)
 
     def do_watch(self):
         """
@@ -271,15 +263,22 @@ class Responder:
 
                 if self.last_known_block == block.get("previousblockhash"):
                     self.check_confirmations(txids)
-
-                    height = block.get("height")
-                    completed_trackers = self.get_completed_trackers(height)
-                    Cleaner.delete_completed_trackers(
-                        completed_trackers, height, self.trackers, self.tx_tracker_map, self.db_manager
+                    Cleaner.delete_trackers(
+                        self.get_completed_trackers(),
+                        block.get("height"),
+                        self.trackers,
+                        self.tx_tracker_map,
+                        self.db_manager,
                     )
-
-                    txs_to_rebroadcast = self.get_txs_to_rebroadcast()
-                    self.rebroadcast(txs_to_rebroadcast)
+                    Cleaner.delete_trackers(
+                        self.get_expired_trackers(block.get("height")),
+                        block.get("height"),
+                        self.trackers,
+                        self.tx_tracker_map,
+                        self.db_manager,
+                        expired=True,
+                    )
+                    self.rebroadcast(self.get_txs_to_rebroadcast())
 
                 # NOTCOVERED
                 else:
@@ -295,7 +294,7 @@ class Responder:
                 # Clear the receipts issued in this block
                 self.carrier.issued_receipts = {}
 
-                if len(self.trackers) != 0:
+                if len(self.trackers) == 0:
                     logger.info("No more pending trackers")
 
             # Register the last processed block for the responder
@@ -349,40 +348,56 @@ class Responder:
 
         return txs_to_rebroadcast
 
-    def get_completed_trackers(self, height):
+    def get_completed_trackers(self):
         """
-        Gets the trackers that has already been fulfilled based on a given height (``end_time`` was reached with a
-        minimum confirmation count).
+        Gets the trackers that has already been fulfilled based on a given height (the justice transaction is
+        irrevocably resolved).
+
+        Returns:
+            :obj:`list`: a list of completed trackers uuids.
+        """
+
+        completed_trackers = []
+        # FIXME: This is here for duplicated penalties, we should be able to get rid of it once we prevent duplicates in
+        #        the responder.
+        checked_txs = {}
+
+        for uuid, tracker_data in self.trackers.items():
+            if tracker_data.get("penalty_txid") not in self.unconfirmed_txs:
+                if tracker_data.get("penalty_txid") not in checked_txs:
+                    tx = self.carrier.get_transaction(tracker_data.get("penalty_txid"))
+                else:
+                    tx = checked_txs.get(tracker_data.get("penalty_txid"))
+
+                if tx is not None:
+                    confirmations = tx.get("confirmations")
+                    checked_txs[tracker_data.get("penalty_txid")] = tx
+
+                    if confirmations is not None and confirmations >= IRREVOCABLY_RESOLVED:
+                        # The end of the appointment has been reached
+                        completed_trackers.append(uuid)
+
+        return completed_trackers
+
+    def get_expired_trackers(self, height):
+        """
+        Gets trackers than are expired due to the user subscription expiring.
+
+        Only gets those trackers which penalty transaction is not going trough (probably because of low fees), the rest
+        will be eventually completed once they are irrevocably resolved.
 
         Args:
             height (:obj:`int`): the height of the last received block.
 
         Returns:
-            :obj:`dict`: a dict (``uuid:confirmations``) of the completed trackers.
+            :obj:`list`: a list of the expired trackers uuids.
         """
 
-        completed_trackers = {}
-        checked_txs = {}
+        expired_trackers = [
+            uuid for uuid in self.gatekeeper.get_expired_appointment(height) if uuid in self.unconfirmed_txs
+        ]
 
-        for uuid, tracker_data in self.trackers.items():
-            appointment_end = tracker_data.get("appointment_end")
-            penalty_txid = tracker_data.get("penalty_txid")
-            if appointment_end <= height and penalty_txid not in self.unconfirmed_txs:
-
-                if penalty_txid not in checked_txs:
-                    tx = self.carrier.get_transaction(penalty_txid)
-                else:
-                    tx = checked_txs.get(penalty_txid)
-
-                if tx is not None:
-                    confirmations = tx.get("confirmations")
-                    checked_txs[penalty_txid] = tx
-
-                    if confirmations is not None and confirmations >= MIN_CONFIRMATIONS:
-                        # The end of the appointment has been reached
-                        completed_trackers[uuid] = confirmations
-
-        return completed_trackers
+        return expired_trackers
 
     def rebroadcast(self, txs_to_rebroadcast):
         """
@@ -465,7 +480,7 @@ class Responder:
                         tracker.dispute_txid,
                         tracker.penalty_txid,
                         tracker.penalty_rawtx,
-                        tracker.appointment_end,
+                        tracker.user_id,
                         block_hash,
                     )
 

--- a/teos/responder.py
+++ b/teos/responder.py
@@ -116,6 +116,8 @@ class Responder:
         is populated by the :obj:`ChainMonitor <teos.chain_monitor.ChainMonitor>`.
         db_manager (:obj:`AppointmentsDBM <teos.appointments_dbm.AppointmentsDBM>`): a ``AppointmentsDBM`` instance
             to interact with the database.
+        gatekeeper (:obj:`Gatekeeper <teos.gatekeeper.Gatekeeper>`): a `Gatekeeper` instance in charge to control the
+            user access and subscription expiry.
         carrier (:obj:`Carrier <teos.carrier.Carrier>`): a ``Carrier`` instance to send transactions to bitcoind.
         block_processor (:obj:`BlockProcessor <teos.block_processor.BlockProcessor>`): a ``BlockProcessor`` instance to
             get data from bitcoind.
@@ -394,7 +396,7 @@ class Responder:
         """
 
         expired_trackers = [
-            uuid for uuid in self.gatekeeper.get_expired_appointment(height) if uuid in self.unconfirmed_txs
+            uuid for uuid in self.gatekeeper.get_expired_appointments(height) if uuid in self.unconfirmed_txs
         ]
 
         return expired_trackers
@@ -402,7 +404,7 @@ class Responder:
     def rebroadcast(self, txs_to_rebroadcast):
         """
         Rebroadcasts a ``penalty_tx`` that has missed too many confirmations. In the current approach this would loop
-        forever if the transaction keeps not getting it.
+        until the tracker expires if the penalty transactions keeps getting rejected due to fees.
 
         Potentially, the fees could be bumped here if the transaction has some tower dedicated outputs (or allows it
         trough ``ANYONECANPAY`` or something similar).

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -70,14 +70,17 @@ def main(command_line_conf):
             block_processor = BlockProcessor(bitcoind_connect_params)
             carrier = Carrier(bitcoind_connect_params)
 
-            responder = Responder(db_manager, carrier, block_processor)
-            watcher = Watcher(
-                db_manager,
+            gatekeeper = Gatekeeper(
+                UsersDBM(config.get("USERS_DB_PATH")),
                 block_processor,
-                responder,
-                secret_key_der,
-                config.get("MAX_APPOINTMENTS"),
+                config.get("DEFAULT_SLOTS"),
+                config.get("DEFAULT_SUBSCRIPTION_DURATION"),
                 config.get("EXPIRY_DELTA"),
+            )
+
+            responder = Responder(db_manager, gatekeeper, carrier, block_processor)
+            watcher = Watcher(
+                db_manager, gatekeeper, block_processor, responder, secret_key_der, config.get("MAX_APPOINTMENTS")
             )
 
             # Create the chain monitor and start monitoring the chain
@@ -151,12 +154,6 @@ def main(command_line_conf):
             # Fire the API and the ChainMonitor
             # FIXME: 92-block-data-during-bootstrap-db
             chain_monitor.monitor_chain()
-            gatekeeper = Gatekeeper(
-                UsersDBM(config.get("USERS_DB_PATH")),
-                block_processor,
-                config.get("DEFAULT_SLOTS"),
-                config.get("DEFAULT_SUBSCRIPTION_DURATION"),
-            )
             inspector = Inspector(block_processor, config.get("MIN_TO_SELF_DELAY"))
             API(config.get("API_BIND"), config.get("API_PORT"), inspector, watcher, gatekeeper).start()
         except Exception as e:

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -155,7 +155,7 @@ def main(command_line_conf):
             # FIXME: 92-block-data-during-bootstrap-db
             chain_monitor.monitor_chain()
             inspector = Inspector(block_processor, config.get("MIN_TO_SELF_DELAY"))
-            API(config.get("API_BIND"), config.get("API_PORT"), inspector, watcher, gatekeeper).start()
+            API(config.get("API_BIND"), config.get("API_PORT"), inspector, watcher).start()
         except Exception as e:
             logger.error("An error occurred: {}. Shutting down".format(e))
             exit(1)

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -151,7 +151,12 @@ def main(command_line_conf):
             # Fire the API and the ChainMonitor
             # FIXME: 92-block-data-during-bootstrap-db
             chain_monitor.monitor_chain()
-            gatekeeper = Gatekeeper(UsersDBM(config.get("USERS_DB_PATH")), config.get("DEFAULT_SLOTS"))
+            gatekeeper = Gatekeeper(
+                UsersDBM(config.get("USERS_DB_PATH")),
+                block_processor,
+                config.get("DEFAULT_SLOTS"),
+                config.get("DEFAULT_SUBSCRIPTION_DURATION"),
+            )
             inspector = Inspector(block_processor, config.get("MIN_TO_SELF_DELAY"))
             API(config.get("API_BIND"), config.get("API_PORT"), inspector, watcher, gatekeeper).start()
         except Exception as e:

--- a/teos/tools.py
+++ b/teos/tools.py
@@ -8,7 +8,6 @@ Tools is a module with general methods that can used by different entities in th
 """
 
 
-# NOTCOVERED
 def bitcoin_cli(btc_connect_params):
     """
     An ``http`` connection with ``bitcoind`` using the ``json-rpc`` interface.

--- a/teos/users_dbm.py
+++ b/teos/users_dbm.py
@@ -37,42 +37,42 @@ class UsersDBM(DBManager):
 
             raise e
 
-    def store_user(self, user_pk, user_data):
+    def store_user(self, user_id, user_data):
         """
         Stores a user record to the database. ``user_pk`` is used as identifier.
 
         Args:
-            user_pk (:obj:`str`): a 33-byte hex-encoded string identifying the user.
+            user_id (:obj:`str`): a 33-byte hex-encoded string identifying the user.
             user_data (:obj:`dict`): the user associated data, as a dictionary.
 
         Returns:
             :obj:`bool`: True if the user was stored in the database, False otherwise.
         """
 
-        if is_compressed_pk(user_pk):
+        if is_compressed_pk(user_id):
             try:
-                self.create_entry(user_pk, json.dumps(user_data))
-                logger.info("Adding user to Gatekeeper's db", user_pk=user_pk)
+                self.create_entry(user_id, json.dumps(user_data))
+                logger.info("Adding user to Gatekeeper's db", user_id=user_id)
                 return True
 
             except json.JSONDecodeError:
-                logger.info("Could't add user to db. Wrong user data format", user_pk=user_pk, user_data=user_data)
+                logger.info("Could't add user to db. Wrong user data format", user_id=user_id, user_data=user_data)
                 return False
 
             except TypeError:
-                logger.info("Could't add user to db", user_pk=user_pk, user_data=user_data)
+                logger.info("Could't add user to db", user_id=user_id, user_data=user_data)
                 return False
         else:
-            logger.info("Could't add user to db. Wrong pk format", user_pk=user_pk, user_data=user_data)
+            logger.info("Could't add user to db. Wrong pk format", user_id=user_id, user_data=user_data)
             return False
 
-    def load_user(self, user_pk):
+    def load_user(self, user_id):
         """
         Loads a user record from the database using the ``user_pk`` as identifier.
 
         Args:
 
-            user_pk (:obj:`str`): a 33-byte hex-encoded string identifying the user.
+            user_id (:obj:`str`): a 33-byte hex-encoded string identifying the user.
 
         Returns:
             :obj:`dict`: A dictionary containing the user data if the ``key`` is found.
@@ -81,31 +81,31 @@ class UsersDBM(DBManager):
         """
 
         try:
-            data = self.load_entry(user_pk)
+            data = self.load_entry(user_id)
             data = json.loads(data)
         except (TypeError, json.decoder.JSONDecodeError):
             data = None
 
         return data
 
-    def delete_user(self, user_pk):
+    def delete_user(self, user_id):
         """
         Deletes a user record from the database.
 
         Args:
-           user_pk (:obj:`str`): a 33-byte hex-encoded string identifying the user.
+           user_id (:obj:`str`): a 33-byte hex-encoded string identifying the user.
 
         Returns:
             :obj:`bool`: True if the user was deleted from the database or it was non-existent, False otherwise.
         """
 
         try:
-            self.delete_entry(user_pk)
-            logger.info("Deleting user from Gatekeeper's db", uuid=user_pk)
+            self.delete_entry(user_id)
+            logger.info("Deleting user from Gatekeeper's db", uuid=user_id)
             return True
 
         except TypeError:
-            logger.info("Cannot delete user from db, user key has wrong type", uuid=user_pk)
+            logger.info("Cannot delete user from db, user key has wrong type", uuid=user_id)
             return False
 
     def load_all_users(self):
@@ -122,7 +122,7 @@ class UsersDBM(DBManager):
 
         for k, v in self.db.iterator():
             # Get uuid and appointment_data from the db
-            user_pk = k.decode("utf-8")
-            data[user_pk] = json.loads(v)
+            user_id = k.decode("utf-8")
+            data[user_id] = json.loads(v)
 
         return data

--- a/teos/watcher.py
+++ b/teos/watcher.py
@@ -95,7 +95,7 @@ class Watcher:
         """
         return self.appointments.get(uuid)
 
-    def add_appointment(self, appointment, user_pk):
+    def add_appointment(self, appointment, user_pk, end_time):
         """
         Adds a new appointment to the ``appointments`` dictionary if ``max_appointments`` has not been reached.
 
@@ -114,6 +114,7 @@ class Watcher:
             appointment (:obj:`Appointment <teos.appointment.Appointment>`): the appointment to be added to the
                 :obj:`Watcher`.
             user_pk(:obj:`str`): the public key that identifies the user who sent the appointment (33-bytes hex str).
+            end_time (:obj:`int`): the block height where the tower will stop watching for breaches.
 
         Returns:
             :obj:`tuple`: A tuple signaling if the appointment has been added or not (based on ``max_appointments``).
@@ -131,7 +132,7 @@ class Watcher:
             uuid = hash_160("{}{}".format(appointment.locator, user_pk))
             self.appointments[uuid] = {
                 "locator": appointment.locator,
-                "end_time": appointment.end_time,
+                "end_time": end_time,
                 "size": len(appointment.encrypted_blob),
             }
 
@@ -143,7 +144,7 @@ class Watcher:
             else:
                 self.locator_uuid_map[appointment.locator] = [uuid]
 
-            self.db_manager.store_watcher_appointment(uuid, appointment.to_dict())
+            self.db_manager.store_watcher_appointment(uuid, appointment.to_dict(), end_time)
             self.db_manager.create_append_locator_map(appointment.locator, uuid)
 
             appointment_added = True

--- a/teos/watcher.py
+++ b/teos/watcher.py
@@ -128,11 +128,12 @@ class Watcher:
         # The uuids are generated as the RIPMED160(locator||user_pubkey).
         # If an appointment is requested by the user the uuid can be recomputed and queried straightaway (no maps).
         uuid = hash_160("{}{}".format(appointment.locator, user_id))
-        appointment_dict = {"locator": appointment.locator, "user_id": user_id, "size": len(appointment.encrypted_blob)}
 
-        available_slots = self.gatekeeper.update_available_slots(user_id, appointment_dict, self.appointments.get(uuid))
+        available_slots = self.gatekeeper.update_available_slots(
+            user_id, appointment.get_summary(), self.appointments.get(uuid)
+        )
         self.gatekeeper.registered_users[user_id].appointments.append(uuid)
-        self.appointments[uuid] = appointment_dict
+        self.appointments[uuid] = appointment.get_summary()
 
         if appointment.locator in self.locator_uuid_map:
             # If the uuid is already in the map it means this is an update.

--- a/teos/watcher.py
+++ b/teos/watcher.py
@@ -124,6 +124,8 @@ class Watcher:
             raise AppointmentLimitReached(message)
 
         user_id = self.gatekeeper.authenticate_user(appointment.serialize(), signature)
+        # The user_id needs to be added to the ExtendedAppointment once the former has been authenticated
+        appointment.user_id = user_id
 
         # The uuids are generated as the RIPMED160(locator||user_pubkey).
         # If an appointment is requested by the user the uuid can be recomputed and queried straightaway (no maps).

--- a/test/common/unit/test_appointment.py
+++ b/test/common/unit/test_appointment.py
@@ -1,5 +1,6 @@
 import struct
 import binascii
+import pytest
 from pytest import fixture
 
 from common.appointment import Appointment
@@ -29,8 +30,6 @@ def appointment_data():
 def test_init_appointment(appointment_data):
     # The appointment has no checks whatsoever, since the inspector is the one taking care or that, and the only one
     # creating appointments.
-    # DISCUSS: whether this makes sense by design or checks should be ported from the inspector to the appointment
-    #          35-appointment-checks
     appointment = Appointment(
         appointment_data["locator"],
         appointment_data["start_time"],
@@ -78,13 +77,9 @@ def test_from_dict(appointment_data):
         prev_val = appointment_data[key]
         appointment_data[key] = None
 
-        try:
+        with pytest.raises(ValueError, match="Wrong appointment data"):
             Appointment.from_dict(appointment_data)
-            assert False
-
-        except ValueError:
             appointment_data[key] = prev_val
-            assert True
 
 
 def test_serialize(appointment_data):

--- a/test/common/unit/test_appointment.py
+++ b/test/common/unit/test_appointment.py
@@ -31,17 +31,11 @@ def test_init_appointment(appointment_data):
     # The appointment has no checks whatsoever, since the inspector is the one taking care or that, and the only one
     # creating appointments.
     appointment = Appointment(
-        appointment_data["locator"],
-        appointment_data["start_time"],
-        appointment_data["end_time"],
-        appointment_data["to_self_delay"],
-        appointment_data["encrypted_blob"],
+        appointment_data["locator"], appointment_data["to_self_delay"], appointment_data["encrypted_blob"]
     )
 
     assert (
         appointment_data["locator"] == appointment.locator
-        and appointment_data["start_time"] == appointment.start_time
-        and appointment_data["end_time"] == appointment.end_time
         and appointment_data["to_self_delay"] == appointment.to_self_delay
         and appointment_data["encrypted_blob"] == appointment.encrypted_blob
     )
@@ -49,19 +43,13 @@ def test_init_appointment(appointment_data):
 
 def test_to_dict(appointment_data):
     appointment = Appointment(
-        appointment_data["locator"],
-        appointment_data["start_time"],
-        appointment_data["end_time"],
-        appointment_data["to_self_delay"],
-        appointment_data["encrypted_blob"],
+        appointment_data["locator"], appointment_data["to_self_delay"], appointment_data["encrypted_blob"]
     )
 
     dict_appointment = appointment.to_dict()
 
     assert (
         appointment_data["locator"] == dict_appointment["locator"]
-        and appointment_data["start_time"] == dict_appointment["start_time"]
-        and appointment_data["end_time"] == dict_appointment["end_time"]
         and appointment_data["to_self_delay"] == dict_appointment["to_self_delay"]
         and appointment_data["encrypted_blob"] == dict_appointment["encrypted_blob"]
     )
@@ -94,13 +82,9 @@ def test_serialize(appointment_data):
     assert isinstance(serialized_appointment, bytes)
 
     locator = serialized_appointment[:16]
-    start_time = serialized_appointment[16:20]
-    end_time = serialized_appointment[20:24]
-    to_self_delay = serialized_appointment[24:28]
-    encrypted_blob = serialized_appointment[28:]
+    to_self_delay = serialized_appointment[16:20]
+    encrypted_blob = serialized_appointment[20:]
 
     assert binascii.hexlify(locator).decode() == appointment.locator
-    assert struct.unpack(">I", start_time)[0] == appointment.start_time
-    assert struct.unpack(">I", end_time)[0] == appointment.end_time
     assert struct.unpack(">I", to_self_delay)[0] == appointment.to_self_delay
     assert binascii.hexlify(encrypted_blob).decode() == appointment.encrypted_blob

--- a/test/teos/e2e/conftest.py
+++ b/test/teos/e2e/conftest.py
@@ -11,7 +11,6 @@ from common.config_loader import ConfigLoader
 
 
 getcontext().prec = 10
-END_TIME_DELTA = 10
 
 
 @pytest.fixture(scope="session")
@@ -123,16 +122,8 @@ def create_penalty_tx(bitcoin_cli, decoded_commitment_tx, destination=None):
     return signed_penalty_tx.get("hex")
 
 
-def build_appointment_data(bitcoin_cli, commitment_tx_id, penalty_tx):
-    current_height = bitcoin_cli.getblockcount()
-
-    appointment_data = {
-        "tx": penalty_tx,
-        "tx_id": commitment_tx_id,
-        "start_time": current_height + 1,
-        "end_time": current_height + 1 + END_TIME_DELTA,
-        "to_self_delay": 20,
-    }
+def build_appointment_data(commitment_tx_id, penalty_tx):
+    appointment_data = {"tx": penalty_tx, "tx_id": commitment_tx_id, "to_self_delay": 20}
 
     return appointment_data
 

--- a/test/teos/unit/conftest.py
+++ b/test/teos/unit/conftest.py
@@ -12,15 +12,14 @@ from bitcoind_mock.transaction import create_dummy_transaction
 
 from teos import DEFAULT_CONF
 from teos.carrier import Carrier
-from teos.tools import bitcoin_cli
 from teos.users_dbm import UsersDBM
 from teos.gatekeeper import Gatekeeper
 from teos.responder import TransactionTracker
 from teos.block_processor import BlockProcessor
 from teos.appointments_dbm import AppointmentsDBM
+from teos.extended_appointment import ExtendedAppointment
 
 from common.tools import compute_locator
-from common.appointment import Appointment
 from common.constants import LOCATOR_LEN_HEX
 from common.config_loader import ConfigLoader
 from common.cryptographer import Cryptographer
@@ -81,8 +80,14 @@ def block_processor():
 
 
 @pytest.fixture(scope="module")
-def gatekeeper(user_db_manager):
-    return Gatekeeper(user_db_manager, get_config().get("DEFAULT_SLOTS"))
+def gatekeeper(user_db_manager, block_processor):
+    return Gatekeeper(
+        user_db_manager,
+        block_processor,
+        get_config().get("DEFAULT_SLOTS"),
+        get_config().get("DEFAULT_SUBSCRIPTION_DURATION"),
+        get_config().get("EXPIRY_DELTA"),
+    )
 
 
 def generate_keypair():
@@ -98,9 +103,19 @@ def get_random_value_hex(nbytes):
     return prv_hex.zfill(2 * nbytes)
 
 
-def generate_block():
+def generate_block_w_delay():
     requests.post(url="http://{}:{}/generate".format(BTC_RPC_HOST, BTC_RPC_PORT), timeout=5)
     sleep(0.5)
+
+
+def generate_blocks_w_delay(n):
+    for _ in range(n):
+        generate_block()
+        sleep(0.2)
+
+
+def generate_block():
+    requests.post(url="http://{}:{}/generate".format(BTC_RPC_HOST, BTC_RPC_PORT), timeout=5)
 
 
 def generate_blocks(n):
@@ -113,38 +128,23 @@ def fork(block_hash):
     requests.post(fork_endpoint, json={"parent": block_hash})
 
 
-def generate_dummy_appointment(real_height=True, start_time_offset=5, end_time_offset=30):
-    if real_height:
-        current_height = bitcoin_cli(bitcoind_connect_params).getblockcount()
-
-    else:
-        current_height = 10
-
+def generate_dummy_appointment():
     dispute_tx = create_dummy_transaction()
     dispute_txid = dispute_tx.tx_id.hex()
     penalty_tx = create_dummy_transaction(dispute_txid)
 
-    dummy_appointment_data = {
-        "tx": penalty_tx.hex(),
-        "tx_id": dispute_txid,
-        "start_time": current_height + start_time_offset,
-        "end_time": current_height + end_time_offset,
-        "to_self_delay": 20,
-    }
-
     locator = compute_locator(dispute_txid)
-
+    dummy_appointment_data = {"tx": penalty_tx.hex(), "tx_id": dispute_txid, "to_self_delay": 20}
     encrypted_blob = Cryptographer.encrypt(dummy_appointment_data.get("tx"), dummy_appointment_data.get("tx_id"))
 
     appointment_data = {
         "locator": locator,
-        "start_time": dummy_appointment_data.get("start_time"),
-        "end_time": dummy_appointment_data.get("end_time"),
         "to_self_delay": dummy_appointment_data.get("to_self_delay"),
         "encrypted_blob": encrypted_blob,
+        "user_id": get_random_value_hex(16),
     }
 
-    return Appointment.from_dict(appointment_data), dispute_tx.hex()
+    return ExtendedAppointment.from_dict(appointment_data), dispute_tx.hex()
 
 
 def generate_dummy_tracker():
@@ -158,7 +158,7 @@ def generate_dummy_tracker():
         dispute_txid=dispute_txid,
         penalty_txid=penalty_txid,
         penalty_rawtx=penalty_rawtx,
-        appointment_end=100,
+        user_id=get_random_value_hex(16),
     )
 
     return TransactionTracker.from_dict(tracker_data)

--- a/test/teos/unit/test_appointments_dbm.py
+++ b/test/teos/unit/test_appointments_dbm.py
@@ -19,7 +19,7 @@ from test.teos.unit.conftest import get_random_value_hex, generate_dummy_appoint
 
 @pytest.fixture(scope="module")
 def watcher_appointments():
-    return {uuid4().hex: generate_dummy_appointment(real_height=False)[0] for _ in range(10)}
+    return {uuid4().hex: generate_dummy_appointment()[0] for _ in range(10)}
 
 
 @pytest.fixture(scope="module")
@@ -215,7 +215,7 @@ def test_store_load_triggered_appointment(db_manager):
     assert db_watcher_appointments == db_watcher_appointments_with_triggered
 
     # Create an appointment flagged as triggered
-    triggered_appointment, _ = generate_dummy_appointment(real_height=False)
+    triggered_appointment, _ = generate_dummy_appointment()
     uuid = uuid4().hex
     assert db_manager.store_watcher_appointment(uuid, triggered_appointment.to_dict()) is True
     db_manager.create_triggered_appointment_flag(uuid)

--- a/test/teos/unit/test_builder.py
+++ b/test/teos/unit/test_builder.py
@@ -47,7 +47,6 @@ def test_build_appointments():
         assert uuid in appointments_data.keys()
         assert appointments_data[uuid].get("locator") == appointment.get("locator")
         assert appointments_data[uuid].get("user_id") == appointment.get("user_id")
-        assert len(appointments_data[uuid].get("encrypted_blob")) == appointment.get("size")
         assert uuid in locator_uuid_map[appointment.get("locator")]
 
 

--- a/test/teos/unit/test_builder.py
+++ b/test/teos/unit/test_builder.py
@@ -4,6 +4,7 @@ from queue import Queue
 
 from teos.builder import Builder
 from teos.watcher import Watcher
+from teos.tools import bitcoin_cli
 from teos.responder import Responder
 
 from test.teos.unit.conftest import (
@@ -11,7 +12,6 @@ from test.teos.unit.conftest import (
     generate_dummy_appointment,
     generate_dummy_tracker,
     generate_block,
-    bitcoin_cli,
     get_config,
     bitcoind_connect_params,
     generate_keypair,
@@ -25,7 +25,7 @@ def test_build_appointments():
 
     # Create some appointment data
     for i in range(10):
-        appointment, _ = generate_dummy_appointment(real_height=False)
+        appointment, _ = generate_dummy_appointment()
         uuid = uuid4().hex
 
         appointments_data[uuid] = appointment.to_dict()
@@ -33,7 +33,7 @@ def test_build_appointments():
         # Add some additional appointments that share the same locator to test all the builder's cases
         if i % 2 == 0:
             locator = appointment.locator
-            appointment, _ = generate_dummy_appointment(real_height=False)
+            appointment, _ = generate_dummy_appointment()
             uuid = uuid4().hex
             appointment.locator = locator
 
@@ -46,7 +46,7 @@ def test_build_appointments():
     for uuid, appointment in appointments.items():
         assert uuid in appointments_data.keys()
         assert appointments_data[uuid].get("locator") == appointment.get("locator")
-        assert appointments_data[uuid].get("end_time") == appointment.get("end_time")
+        assert appointments_data[uuid].get("user_id") == appointment.get("user_id")
         assert len(appointments_data[uuid].get("encrypted_blob")) == appointment.get("size")
         assert uuid in locator_uuid_map[appointment.get("locator")]
 
@@ -76,7 +76,7 @@ def test_build_trackers():
 
         assert tracker.get("penalty_txid") == trackers_data[uuid].get("penalty_txid")
         assert tracker.get("locator") == trackers_data[uuid].get("locator")
-        assert tracker.get("appointment_end") == trackers_data[uuid].get("appointment_end")
+        assert tracker.get("user_id") == trackers_data[uuid].get("user_id")
         assert uuid in tx_tracker_map[tracker.get("penalty_txid")]
 
 
@@ -95,14 +95,14 @@ def test_populate_block_queue():
     assert len(blocks) == 0
 
 
-def test_update_states_empty_list(db_manager, carrier, block_processor):
+def test_update_states_empty_list(db_manager, gatekeeper, carrier, block_processor):
     w = Watcher(
         db_manager=db_manager,
+        gatekeeper=gatekeeper,
         block_processor=block_processor,
-        responder=Responder(db_manager, carrier, block_processor),
+        responder=Responder(db_manager, gatekeeper, carrier, block_processor),
         sk_der=generate_keypair()[0].to_der(),
         max_appointments=config.get("MAX_APPOINTMENTS"),
-        expiry_delta=config.get("EXPIRY_DELTA"),
     )
 
     missed_blocks_watcher = []
@@ -116,14 +116,14 @@ def test_update_states_empty_list(db_manager, carrier, block_processor):
         Builder.update_states(w, missed_blocks_responder, missed_blocks_watcher)
 
 
-def test_update_states_responder_misses_more(run_bitcoind, db_manager, carrier, block_processor):
+def test_update_states_responder_misses_more(run_bitcoind, db_manager, gatekeeper, carrier, block_processor):
     w = Watcher(
         db_manager=db_manager,
+        gatekeeper=gatekeeper,
         block_processor=block_processor,
-        responder=Responder(db_manager, carrier, block_processor),
+        responder=Responder(db_manager, gatekeeper, carrier, block_processor),
         sk_der=generate_keypair()[0].to_der(),
         max_appointments=config.get("MAX_APPOINTMENTS"),
-        expiry_delta=config.get("EXPIRY_DELTA"),
     )
 
     blocks = []
@@ -140,15 +140,15 @@ def test_update_states_responder_misses_more(run_bitcoind, db_manager, carrier, 
     assert w.responder.last_known_block == blocks[-1]
 
 
-def test_update_states_watcher_misses_more(db_manager, carrier, block_processor):
+def test_update_states_watcher_misses_more(db_manager, gatekeeper, carrier, block_processor):
     # Same as before, but data is now in the Responder
     w = Watcher(
         db_manager=db_manager,
+        gatekeeper=gatekeeper,
         block_processor=block_processor,
-        responder=Responder(db_manager, carrier, block_processor),
+        responder=Responder(db_manager, gatekeeper, carrier, block_processor),
         sk_der=generate_keypair()[0].to_der(),
         max_appointments=config.get("MAX_APPOINTMENTS"),
-        expiry_delta=config.get("EXPIRY_DELTA"),
     )
 
     blocks = []

--- a/test/teos/unit/test_cleaner.py
+++ b/test/teos/unit/test_cleaner.py
@@ -23,7 +23,7 @@ def set_up_appointments(db_manager, total_appointments):
         uuid = uuid4().hex
         locator = get_random_value_hex(LOCATOR_LEN_BYTES)
 
-        appointment = Appointment(locator, None, None, None, None)
+        appointment = Appointment(locator, None, None)
         appointments[uuid] = {"locator": appointment.locator}
         locator_uuid_map[locator] = [uuid]
 
@@ -156,7 +156,8 @@ def test_flag_triggered_appointments(db_manager):
         assert set(triggered_appointments).issubset(db_appointments)
 
 
-def test_delete_completed_trackers_db_match(db_manager):
+def test_delete_trackers_db_match(db_manager):
+    # Completed and expired trackers are deleted using the same method. The only difference is the logging message
     height = 0
 
     for _ in range(ITERATIONS):
@@ -165,12 +166,12 @@ def test_delete_completed_trackers_db_match(db_manager):
 
         completed_trackers = {tracker: 6 for tracker in selected_trackers}
 
-        Cleaner.delete_completed_trackers(completed_trackers, height, trackers, tx_tracker_map, db_manager)
+        Cleaner.delete_trackers(completed_trackers, height, trackers, tx_tracker_map, db_manager)
 
         assert not set(completed_trackers).issubset(trackers.keys())
 
 
-def test_delete_completed_trackers_no_db_match(db_manager):
+def test_delete_trackers_no_db_match(db_manager):
     height = 0
 
     for _ in range(ITERATIONS):
@@ -203,5 +204,5 @@ def test_delete_completed_trackers_no_db_match(db_manager):
         completed_trackers = {tracker: 6 for tracker in selected_trackers}
 
         # We should be able to delete the correct ones and not fail in the others
-        Cleaner.delete_completed_trackers(completed_trackers, height, trackers, tx_tracker_map, db_manager)
+        Cleaner.delete_trackers(completed_trackers, height, trackers, tx_tracker_map, db_manager)
         assert not set(completed_trackers).issubset(trackers.keys())

--- a/test/teos/unit/test_cleaner.py
+++ b/test/teos/unit/test_cleaner.py
@@ -1,8 +1,9 @@
 import random
 from uuid import uuid4
 
-from teos.responder import TransactionTracker
 from teos.cleaner import Cleaner
+from teos.gatekeeper import UserInfo
+from teos.responder import TransactionTracker
 from common.appointment import Appointment
 
 from test.teos.unit.conftest import get_random_value_hex
@@ -206,3 +207,36 @@ def test_delete_trackers_no_db_match(db_manager):
         # We should be able to delete the correct ones and not fail in the others
         Cleaner.delete_trackers(completed_trackers, height, trackers, tx_tracker_map, db_manager)
         assert not set(completed_trackers).issubset(trackers.keys())
+
+
+def test_delete_gatekeeper_appointments(gatekeeper):
+    # delete_gatekeeper_appointments should delete the appointments from user as long as both exist
+
+    appointments_not_to_delete = {}
+    appointments_to_delete = {}
+    # Let's add some users and appointments to the Gatekeeper
+    for _ in range(10):
+        user_id = get_random_value_hex(16)
+        # The UserInfo params do not matter much here
+        gatekeeper.registered_users[user_id] = UserInfo(available_slots=100, subscription_expiry=0)
+        for _ in range(random.randint(0, 10)):
+            # Add some appointments
+            uuid = get_random_value_hex(16)
+            gatekeeper.registered_users[user_id].appointments[uuid] = 1
+
+            if random.randint(0, 1) % 2:
+                appointments_to_delete[uuid] = user_id
+            else:
+                appointments_not_to_delete[uuid] = user_id
+
+    # Now let's delete half of them
+    Cleaner.delete_gatekeeper_appointments(gatekeeper, appointments_to_delete)
+
+    all_appointments_gatekeeper = []
+    # Let's get all the appointments in the Gatekeeper
+    for user_id, user in gatekeeper.registered_users.items():
+        all_appointments_gatekeeper.extend(user.appointments)
+
+    # Check that the first half of the appointments are not in the Gatekeeper, but the second half is
+    assert not set(appointments_to_delete).issubset(all_appointments_gatekeeper)
+    assert set(appointments_not_to_delete).issubset(all_appointments_gatekeeper)

--- a/test/teos/unit/test_extended_appointment.py
+++ b/test/teos/unit/test_extended_appointment.py
@@ -1,0 +1,56 @@
+import pytest
+from pytest import fixture
+
+from common.constants import LOCATOR_LEN_BYTES
+from teos.extended_appointment import ExtendedAppointment
+
+from test.common.unit.conftest import get_random_value_hex
+
+
+# Parent methods are not tested.
+@fixture
+def appointment_data():
+    locator = get_random_value_hex(LOCATOR_LEN_BYTES)
+    to_self_delay = 20
+    user_id = get_random_value_hex(16)
+    encrypted_blob_data = get_random_value_hex(100)
+
+    return {
+        "locator": locator,
+        "to_self_delay": to_self_delay,
+        "encrypted_blob": encrypted_blob_data,
+        "user_id": user_id,
+    }
+
+
+def test_init_appointment(appointment_data):
+    # The appointment has no checks whatsoever, since the inspector is the one taking care or that, and the only one
+    # creating appointments.
+    appointment = ExtendedAppointment(
+        appointment_data["locator"],
+        appointment_data["to_self_delay"],
+        appointment_data["encrypted_blob"],
+        appointment_data["user_id"],
+    )
+
+    assert (
+        appointment_data["locator"] == appointment.locator
+        and appointment_data["to_self_delay"] == appointment.to_self_delay
+        and appointment_data["encrypted_blob"] == appointment.encrypted_blob
+        and appointment_data["user_id"] == appointment.user_id
+    )
+
+
+def test_from_dict(appointment_data):
+    # The appointment should be build if we don't miss any field
+    appointment = ExtendedAppointment.from_dict(appointment_data)
+    assert isinstance(appointment, ExtendedAppointment)
+
+    # Otherwise it should fail
+    for key in appointment_data.keys():
+        prev_val = appointment_data[key]
+        appointment_data[key] = None
+
+        with pytest.raises(ValueError, match="Wrong appointment data"):
+            ExtendedAppointment.from_dict(appointment_data)
+            appointment_data[key] = prev_val

--- a/test/teos/unit/test_extended_appointment.py
+++ b/test/teos/unit/test_extended_appointment.py
@@ -45,7 +45,6 @@ def test_get_summary(appointment_data):
     assert ExtendedAppointment.from_dict(appointment_data).get_summary() == {
         "locator": appointment_data["locator"],
         "user_id": appointment_data["user_id"],
-        "size": len(appointment_data["encrypted_blob"]),
     }
 
 

--- a/test/teos/unit/test_extended_appointment.py
+++ b/test/teos/unit/test_extended_appointment.py
@@ -41,6 +41,14 @@ def test_init_appointment(appointment_data):
     )
 
 
+def test_get_summary(appointment_data):
+    assert ExtendedAppointment.from_dict(appointment_data).get_summary() == {
+        "locator": appointment_data["locator"],
+        "user_id": appointment_data["user_id"],
+        "size": len(appointment_data["encrypted_blob"]),
+    }
+
+
 def test_from_dict(appointment_data):
     # The appointment should be build if we don't miss any field
     appointment = ExtendedAppointment.from_dict(appointment_data)

--- a/test/teos/unit/test_gatekeeper.py
+++ b/test/teos/unit/test_gatekeeper.py
@@ -28,17 +28,17 @@ def test_init(gatekeeper, run_bitcoind):
 def test_add_update_user(gatekeeper):
     # add_update_user adds DEFAULT_SLOTS to a given user as long as the identifier is {02, 03}| 32-byte hex str
     # it also add DEFAULT_SUBSCRIPTION_DURATION + current_block_height to the user
-    user_pk = "02" + get_random_value_hex(32)
+    user_id = "02" + get_random_value_hex(32)
 
     for _ in range(10):
-        user = gatekeeper.registered_users.get(user_pk)
+        user = gatekeeper.registered_users.get(user_id)
         current_slots = user.available_slots if user is not None else 0
 
-        gatekeeper.add_update_user(user_pk)
+        gatekeeper.add_update_user(user_id)
 
-        assert gatekeeper.registered_users.get(user_pk).available_slots == current_slots + config.get("DEFAULT_SLOTS")
+        assert gatekeeper.registered_users.get(user_id).available_slots == current_slots + config.get("DEFAULT_SLOTS")
         assert gatekeeper.registered_users[
-            user_pk
+            user_id
         ].subscription_expiry == gatekeeper.block_processor.get_block_count() + config.get(
             "DEFAULT_SUBSCRIPTION_DURATION"
         )
@@ -46,31 +46,31 @@ def test_add_update_user(gatekeeper):
     # The same can be checked for multiple users
     for _ in range(10):
         # The user identifier is changed every call
-        user_pk = "03" + get_random_value_hex(32)
+        user_id = "03" + get_random_value_hex(32)
 
-        gatekeeper.add_update_user(user_pk)
-        assert gatekeeper.registered_users.get(user_pk).available_slots == config.get("DEFAULT_SLOTS")
+        gatekeeper.add_update_user(user_id)
+        assert gatekeeper.registered_users.get(user_id).available_slots == config.get("DEFAULT_SLOTS")
         assert gatekeeper.registered_users[
-            user_pk
+            user_id
         ].subscription_expiry == gatekeeper.block_processor.get_block_count() + config.get(
             "DEFAULT_SUBSCRIPTION_DURATION"
         )
 
 
-def test_add_update_user_wrong_pk(gatekeeper):
+def test_add_update_user_wrong_id(gatekeeper):
     # Passing a wrong pk defaults to the errors in check_user_pk. We can try with one.
-    wrong_pk = get_random_value_hex(32)
+    wrong_id = get_random_value_hex(32)
 
     with pytest.raises(InvalidParameter):
-        gatekeeper.add_update_user(wrong_pk)
+        gatekeeper.add_update_user(wrong_id)
 
 
-def test_add_update_user_wrong_pk_prefix(gatekeeper):
+def test_add_update_user_wrong_id_prefix(gatekeeper):
     # Prefixes must be 02 or 03, anything else should fail
-    wrong_pk = "04" + get_random_value_hex(32)
+    wrong_id = "04" + get_random_value_hex(32)
 
     with pytest.raises(InvalidParameter):
-        gatekeeper.add_update_user(wrong_pk)
+        gatekeeper.add_update_user(wrong_id)
 
 
 def test_identify_user(gatekeeper):
@@ -79,13 +79,13 @@ def test_identify_user(gatekeeper):
 
     # Let's first register a user
     sk, pk = generate_keypair()
-    compressed_pk = Cryptographer.get_compressed_pk(pk)
-    gatekeeper.add_update_user(compressed_pk)
+    user_id = Cryptographer.get_compressed_pk(pk)
+    gatekeeper.add_update_user(user_id)
 
     message = "Hey, it's me"
     signature = Cryptographer.sign(message.encode(), sk)
 
-    assert gatekeeper.authenticate_user(message.encode(), signature) == compressed_pk
+    assert gatekeeper.authenticate_user(message.encode(), signature) == user_id
 
 
 def test_identify_user_non_registered(gatekeeper):
@@ -132,15 +132,15 @@ def test_update_available_slots(gatekeeper):
     # update_available_slots should decrease the slot count if a new appointment is added
     # let's add a new user
     sk, pk = generate_keypair()
-    compressed_pk = Cryptographer.get_compressed_pk(pk)
-    gatekeeper.add_update_user(compressed_pk)
+    user_id = Cryptographer.get_compressed_pk(pk)
+    gatekeeper.add_update_user(user_id)
 
     # And now update the slots given an appointment
     appointment, _ = generate_dummy_appointment()
-    gatekeeper.update_available_slots(compressed_pk, appointment.get_summary())
+    gatekeeper.update_available_slots(user_id, appointment.get_summary())
 
     # This is a standard size appointment, so it should have reduced the slots by one
-    assert gatekeeper.registered_users[compressed_pk].available_slots == config.get("DEFAULT_SLOTS") - 1
+    assert gatekeeper.registered_users[user_id].available_slots == config.get("DEFAULT_SLOTS") - 1
 
     # Updates can leave the count as it, decrease it, or increase it, depending on the appointment size (modulo
     # ENCRYPTED_BLOB_MAX_SIZE_HEX)
@@ -148,7 +148,7 @@ def test_update_available_slots(gatekeeper):
     # Appointments of the same size leave it as is
     appointment_same_size, _ = generate_dummy_appointment()
     remaining_slots = gatekeeper.update_available_slots(
-        compressed_pk, appointment.get_summary(), appointment_same_size.get_summary()
+        user_id, appointment.get_summary(), appointment_same_size.get_summary()
     )
     assert remaining_slots == config.get("DEFAULT_SLOTS") - 1
 
@@ -156,20 +156,20 @@ def test_update_available_slots(gatekeeper):
     appointment_x2_size = appointment_same_size
     appointment_x2_size.encrypted_blob = "A" * (ENCRYPTED_BLOB_MAX_SIZE_HEX + 1)
     remaining_slots = gatekeeper.update_available_slots(
-        compressed_pk, appointment_x2_size.get_summary(), appointment.get_summary()
+        user_id, appointment_x2_size.get_summary(), appointment.get_summary()
     )
     assert remaining_slots == config.get("DEFAULT_SLOTS") - 2
 
     # Smaller appointments increase it (using the same data but flipped)
     remaining_slots = gatekeeper.update_available_slots(
-        compressed_pk, appointment.get_summary(), appointment_x2_size.get_summary()
+        user_id, appointment.get_summary(), appointment_x2_size.get_summary()
     )
     assert remaining_slots == config.get("DEFAULT_SLOTS") - 1
 
     # If the appointment needs more slots than there's free, it should fail
-    gatekeeper.registered_users[compressed_pk].available_slots = 1
+    gatekeeper.registered_users[user_id].available_slots = 1
     with pytest.raises(NotEnoughSlots):
-        gatekeeper.update_available_slots(compressed_pk, appointment_x2_size.get_summary())
+        gatekeeper.update_available_slots(user_id, appointment_x2_size.get_summary())
 
 
 def test_get_expired_appointments(gatekeeper):

--- a/test/teos/unit/test_gatekeeper.py
+++ b/test/teos/unit/test_gatekeeper.py
@@ -1,8 +1,9 @@
 import pytest
 
-from teos.gatekeeper import IdentificationFailure, NotEnoughSlots
+from teos.gatekeeper import AuthenticationFailure, NotEnoughSlots
 
 from common.cryptographer import Cryptographer
+from common.exceptions import InvalidParameter
 
 from test.teos.unit.conftest import get_random_value_hex, generate_keypair, get_config
 
@@ -10,7 +11,7 @@ from test.teos.unit.conftest import get_random_value_hex, generate_keypair, get_
 config = get_config()
 
 
-def test_init(gatekeeper):
+def test_init(gatekeeper, run_bitcoind):
     assert isinstance(gatekeeper.default_slots, int) and gatekeeper.default_slots == config.get("DEFAULT_SLOTS")
     assert isinstance(gatekeeper.registered_users, dict) and len(gatekeeper.registered_users) == 0
 
@@ -20,14 +21,12 @@ def test_add_update_user(gatekeeper):
     user_pk = "02" + get_random_value_hex(32)
 
     for _ in range(10):
-        current_slots = gatekeeper.registered_users.get(user_pk)
-        current_slots = current_slots.get("available_slots") if current_slots is not None else 0
+        user = gatekeeper.registered_users.get(user_pk)
+        current_slots = user.available_slots if user is not None else 0
 
         gatekeeper.add_update_user(user_pk)
 
-        assert gatekeeper.registered_users.get(user_pk).get("available_slots") == current_slots + config.get(
-            "DEFAULT_SLOTS"
-        )
+        assert gatekeeper.registered_users.get(user_pk).available_slots == current_slots + config.get("DEFAULT_SLOTS")
 
     # The same can be checked for multiple users
     for _ in range(10):
@@ -35,14 +34,14 @@ def test_add_update_user(gatekeeper):
         user_pk = "03" + get_random_value_hex(32)
 
         gatekeeper.add_update_user(user_pk)
-        assert gatekeeper.registered_users.get(user_pk).get("available_slots") == config.get("DEFAULT_SLOTS")
+        assert gatekeeper.registered_users.get(user_pk).available_slots == config.get("DEFAULT_SLOTS")
 
 
 def test_add_update_user_wrong_pk(gatekeeper):
     # Passing a wrong pk defaults to the errors in check_user_pk. We can try with one.
     wrong_pk = get_random_value_hex(32)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidParameter):
         gatekeeper.add_update_user(wrong_pk)
 
 
@@ -50,7 +49,7 @@ def test_add_update_user_wrong_pk_prefix(gatekeeper):
     # Prefixes must be 02 or 03, anything else should fail
     wrong_pk = "04" + get_random_value_hex(32)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidParameter):
         gatekeeper.add_update_user(wrong_pk)
 
 
@@ -66,7 +65,7 @@ def test_identify_user(gatekeeper):
     message = "Hey, it's me"
     signature = Cryptographer.sign(message.encode(), sk)
 
-    assert gatekeeper.identify_user(message.encode(), signature) == compressed_pk
+    assert gatekeeper.authenticate_user(message.encode(), signature) == compressed_pk
 
 
 def test_identify_user_non_registered(gatekeeper):
@@ -76,8 +75,8 @@ def test_identify_user_non_registered(gatekeeper):
     message = "Hey, it's me"
     signature = Cryptographer.sign(message.encode(), sk)
 
-    with pytest.raises(IdentificationFailure):
-        gatekeeper.identify_user(message.encode(), signature)
+    with pytest.raises(AuthenticationFailure):
+        gatekeeper.authenticate_user(message.encode(), signature)
 
 
 def test_identify_user_invalid_signature(gatekeeper):
@@ -85,8 +84,8 @@ def test_identify_user_invalid_signature(gatekeeper):
     message = "Hey, it's me"
     signature = get_random_value_hex(72)
 
-    with pytest.raises(IdentificationFailure):
-        gatekeeper.identify_user(message.encode(), signature)
+    with pytest.raises(AuthenticationFailure):
+        gatekeeper.authenticate_user(message.encode(), signature)
 
 
 def test_identify_user_wrong(gatekeeper):
@@ -97,41 +96,16 @@ def test_identify_user_wrong(gatekeeper):
     signature = Cryptographer.sign(message.encode(), sk)
 
     # Non-byte message and str sig
-    with pytest.raises(IdentificationFailure):
-        gatekeeper.identify_user(message, signature)
+    with pytest.raises(AuthenticationFailure):
+        gatekeeper.authenticate_user(message, signature)
 
     # byte message and non-str sig
-    with pytest.raises(IdentificationFailure):
-        gatekeeper.identify_user(message.encode(), signature.encode())
+    with pytest.raises(AuthenticationFailure):
+        gatekeeper.authenticate_user(message.encode(), signature.encode())
 
     # non-byte message and non-str sig
-    with pytest.raises(IdentificationFailure):
-        gatekeeper.identify_user(message, signature.encode())
+    with pytest.raises(AuthenticationFailure):
+        gatekeeper.authenticate_user(message, signature.encode())
 
 
-def test_fill_slots(gatekeeper):
-    # Free slots will decrease the slot count of a user as long as he has enough slots, otherwise raise NotEnoughSlots
-    user_pk = "02" + get_random_value_hex(32)
-    gatekeeper.add_update_user(user_pk)
-
-    gatekeeper.fill_slots(user_pk, config.get("DEFAULT_SLOTS") - 1)
-    assert gatekeeper.registered_users.get(user_pk).get("available_slots") == 1
-
-    with pytest.raises(NotEnoughSlots):
-        gatekeeper.fill_slots(user_pk, 2)
-
-    # NotEnoughSlots is also raised if the user does not exist
-    with pytest.raises(NotEnoughSlots):
-        gatekeeper.fill_slots(get_random_value_hex(33), 2)
-
-
-def test_free_slots(gatekeeper):
-    # Free slots simply adds slots to the user as long as it exists.
-    user_pk = "03" + get_random_value_hex(32)
-    gatekeeper.add_update_user(user_pk)
-    gatekeeper.free_slots(user_pk, 42)
-
-    assert gatekeeper.registered_users.get(user_pk).get("available_slots") == config.get("DEFAULT_SLOTS") + 42
-
-    # Just making sure it does not crash for non-registered user
-    assert gatekeeper.free_slots(get_random_value_hex(33), 10) is None
+# FIXME: MISSING TESTS

--- a/test/teos/unit/test_gatekeeper.py
+++ b/test/teos/unit/test_gatekeeper.py
@@ -1,11 +1,14 @@
 import pytest
 
-from teos.gatekeeper import AuthenticationFailure, NotEnoughSlots
+from teos.users_dbm import UsersDBM
+from teos.block_processor import BlockProcessor
+from teos.gatekeeper import AuthenticationFailure, NotEnoughSlots, UserInfo
 
 from common.cryptographer import Cryptographer
 from common.exceptions import InvalidParameter
+from common.constants import ENCRYPTED_BLOB_MAX_SIZE_HEX
 
-from test.teos.unit.conftest import get_random_value_hex, generate_keypair, get_config
+from test.teos.unit.conftest import get_random_value_hex, generate_keypair, get_config, generate_dummy_appointment
 
 
 config = get_config()
@@ -13,11 +16,18 @@ config = get_config()
 
 def test_init(gatekeeper, run_bitcoind):
     assert isinstance(gatekeeper.default_slots, int) and gatekeeper.default_slots == config.get("DEFAULT_SLOTS")
+    assert isinstance(
+        gatekeeper.default_subscription_duration, int
+    ) and gatekeeper.default_subscription_duration == config.get("DEFAULT_SUBSCRIPTION_DURATION")
+    assert isinstance(gatekeeper.expiry_delta, int) and gatekeeper.expiry_delta == config.get("EXPIRY_DELTA")
+    assert isinstance(gatekeeper.block_processor, BlockProcessor)
+    assert isinstance(gatekeeper.user_db, UsersDBM)
     assert isinstance(gatekeeper.registered_users, dict) and len(gatekeeper.registered_users) == 0
 
 
 def test_add_update_user(gatekeeper):
     # add_update_user adds DEFAULT_SLOTS to a given user as long as the identifier is {02, 03}| 32-byte hex str
+    # it also add DEFAULT_SUBSCRIPTION_DURATION + current_block_height to the user
     user_pk = "02" + get_random_value_hex(32)
 
     for _ in range(10):
@@ -27,6 +37,11 @@ def test_add_update_user(gatekeeper):
         gatekeeper.add_update_user(user_pk)
 
         assert gatekeeper.registered_users.get(user_pk).available_slots == current_slots + config.get("DEFAULT_SLOTS")
+        assert gatekeeper.registered_users[
+            user_pk
+        ].subscription_expiry == gatekeeper.block_processor.get_block_count() + config.get(
+            "DEFAULT_SUBSCRIPTION_DURATION"
+        )
 
     # The same can be checked for multiple users
     for _ in range(10):
@@ -35,6 +50,11 @@ def test_add_update_user(gatekeeper):
 
         gatekeeper.add_update_user(user_pk)
         assert gatekeeper.registered_users.get(user_pk).available_slots == config.get("DEFAULT_SLOTS")
+        assert gatekeeper.registered_users[
+            user_pk
+        ].subscription_expiry == gatekeeper.block_processor.get_block_count() + config.get(
+            "DEFAULT_SUBSCRIPTION_DURATION"
+        )
 
 
 def test_add_update_user_wrong_pk(gatekeeper):
@@ -108,4 +128,63 @@ def test_identify_user_wrong(gatekeeper):
         gatekeeper.authenticate_user(message, signature.encode())
 
 
-# FIXME: MISSING TESTS
+def test_update_available_slots(gatekeeper):
+    # update_available_slots should decrease the slot count if a new appointment is added
+    # let's add a new user
+    sk, pk = generate_keypair()
+    compressed_pk = Cryptographer.get_compressed_pk(pk)
+    gatekeeper.add_update_user(compressed_pk)
+
+    # And now update the slots given an appointment
+    appointment, _ = generate_dummy_appointment()
+    gatekeeper.update_available_slots(compressed_pk, appointment.get_summary())
+
+    # This is a standard size appointment, so it should have reduced the slots by one
+    assert gatekeeper.registered_users[compressed_pk].available_slots == config.get("DEFAULT_SLOTS") - 1
+
+    # Updates can leave the count as it, decrease it, or increase it, depending on the appointment size (modulo
+    # ENCRYPTED_BLOB_MAX_SIZE_HEX)
+
+    # Appointments of the same size leave it as is
+    appointment_same_size, _ = generate_dummy_appointment()
+    remaining_slots = gatekeeper.update_available_slots(
+        compressed_pk, appointment.get_summary(), appointment_same_size.get_summary()
+    )
+    assert remaining_slots == config.get("DEFAULT_SLOTS") - 1
+
+    # Bigger appointments decrease it
+    appointment_x2_size = appointment_same_size
+    appointment_x2_size.encrypted_blob = "A" * (ENCRYPTED_BLOB_MAX_SIZE_HEX + 1)
+    remaining_slots = gatekeeper.update_available_slots(
+        compressed_pk, appointment_x2_size.get_summary(), appointment.get_summary()
+    )
+    assert remaining_slots == config.get("DEFAULT_SLOTS") - 2
+
+    # Smaller appointments increase it (using the same data but flipped)
+    remaining_slots = gatekeeper.update_available_slots(
+        compressed_pk, appointment.get_summary(), appointment_x2_size.get_summary()
+    )
+    assert remaining_slots == config.get("DEFAULT_SLOTS") - 1
+
+    # If the appointment needs more slots than there's free, it should fail
+    gatekeeper.registered_users[compressed_pk].available_slots = 1
+    with pytest.raises(NotEnoughSlots):
+        gatekeeper.update_available_slots(compressed_pk, appointment_x2_size.get_summary())
+
+
+def test_get_expired_appointments(gatekeeper):
+    # get_expired_appointments returns a list of appointment uuids expiring at a given block
+
+    appointment = {}
+    # Let's simulate adding some users with dummy expiry times
+    gatekeeper.registered_users = {}
+    for i in reversed(range(100)):
+        uuid = get_random_value_hex(16)
+        user_appointments = [get_random_value_hex(16)]
+        # Add a single appointment to the user
+        gatekeeper.registered_users[uuid] = UserInfo(100, i, user_appointments)
+        appointment[i] = user_appointments
+
+    # Now let's check that reversed
+    for i in range(100):
+        assert gatekeeper.get_expired_appointments(i + gatekeeper.expiry_delta) == appointment[i]

--- a/test/teos/unit/test_tools.py
+++ b/test/teos/unit/test_tools.py
@@ -13,13 +13,7 @@ def test_can_connect_to_bitcoind():
     assert can_connect_to_bitcoind(bitcoind_connect_params) is True
 
 
-# def test_can_connect_to_bitcoind_bitcoin_not_running():
-#     # Kill the simulator thread and test the check fails
-#     bitcoind_process.kill()
-#     assert can_connect_to_bitcoind() is False
-
-
-def test_bitcoin_cli():
+def test_bitcoin_cli(run_bitcoind):
     try:
         bitcoin_cli(bitcoind_connect_params).help()
         assert True

--- a/test/teos/unit/test_users_dbm.py
+++ b/test/teos/unit/test_users_dbm.py
@@ -19,27 +19,27 @@ def open_create_db(db_path):
 
 def test_store_user(user_db_manager):
     # Store user should work as long as the user_pk is properly formatted and data is a dictionary
-    user_pk = "02" + get_random_value_hex(32)
+    user_id = "02" + get_random_value_hex(32)
     user_info = UserInfo(available_slots=42, subscription_expiry=100)
-    stored_users[user_pk] = user_info.to_dict()
-    assert user_db_manager.store_user(user_pk, user_info.to_dict()) is True
+    stored_users[user_id] = user_info.to_dict()
+    assert user_db_manager.store_user(user_id, user_info.to_dict()) is True
 
     # Wrong pks should return False on adding
-    user_pk = "04" + get_random_value_hex(32)
+    user_id = "04" + get_random_value_hex(32)
     user_info = UserInfo(available_slots=42, subscription_expiry=100)
-    assert user_db_manager.store_user(user_pk, user_info.to_dict()) is False
+    assert user_db_manager.store_user(user_id, user_info.to_dict()) is False
 
     # Same for wrong types
     assert user_db_manager.store_user(42, user_info.to_dict()) is False
 
     # And for wrong type user data
-    assert user_db_manager.store_user(user_pk, 42) is False
+    assert user_db_manager.store_user(user_id, 42) is False
 
 
 def test_load_user(user_db_manager):
     # Loading a user we have stored should work
-    for user_pk, user_data in stored_users.items():
-        assert user_db_manager.load_user(user_pk) == user_data
+    for user_id, user_data in stored_users.items():
+        assert user_db_manager.load_user(user_id) == user_data
 
     # Random keys should fail
     assert user_db_manager.load_user(get_random_value_hex(33)) is None
@@ -50,11 +50,11 @@ def test_load_user(user_db_manager):
 
 def test_delete_user(user_db_manager):
     # Deleting an existing user should work
-    for user_pk, user_data in stored_users.items():
-        assert user_db_manager.delete_user(user_pk) is True
+    for user_id, user_data in stored_users.items():
+        assert user_db_manager.delete_user(user_id) is True
 
-    for user_pk, user_data in stored_users.items():
-        assert user_db_manager.load_user(user_pk) is None
+    for user_id, user_data in stored_users.items():
+        assert user_db_manager.load_user(user_id) is None
 
     # But deleting a non existing one should not fail
     assert user_db_manager.delete_user(get_random_value_hex(32)) is True
@@ -70,10 +70,10 @@ def test_load_all_users(user_db_manager):
 
     # Adding some and checking we get them all
     for i in range(10):
-        user_pk = "02" + get_random_value_hex(32)
+        user_id = "02" + get_random_value_hex(32)
         user_info = UserInfo(available_slots=42, subscription_expiry=100)
-        user_db_manager.store_user(user_pk, user_info.to_dict())
-        stored_users[user_pk] = user_info.to_dict()
+        user_db_manager.store_user(user_id, user_info.to_dict())
+        stored_users[user_id] = user_info.to_dict()
 
     all_users = user_db_manager.load_all_users()
 

--- a/test/teos/unit/test_users_dbm.py
+++ b/test/teos/unit/test_users_dbm.py
@@ -1,7 +1,7 @@
-from teos.appointments_dbm import AppointmentsDBM
+from teos.users_dbm import UsersDBM
+from teos.gatekeeper import UserInfo
 
 from test.teos.unit.conftest import get_random_value_hex
-
 
 stored_users = {}
 
@@ -9,7 +9,7 @@ stored_users = {}
 def open_create_db(db_path):
 
     try:
-        db_manager = AppointmentsDBM(db_path)
+        db_manager = UsersDBM(db_path)
 
         return db_manager
 
@@ -20,17 +20,17 @@ def open_create_db(db_path):
 def test_store_user(user_db_manager):
     # Store user should work as long as the user_pk is properly formatted and data is a dictionary
     user_pk = "02" + get_random_value_hex(32)
-    user_data = {"available_slots": 42}
-    stored_users[user_pk] = user_data
-    assert user_db_manager.store_user(user_pk, user_data) is True
+    user_info = UserInfo(available_slots=42, subscription_expiry=100)
+    stored_users[user_pk] = user_info.to_dict()
+    assert user_db_manager.store_user(user_pk, user_info.to_dict()) is True
 
     # Wrong pks should return False on adding
     user_pk = "04" + get_random_value_hex(32)
-    user_data = {"available_slots": 42}
-    assert user_db_manager.store_user(user_pk, user_data) is False
+    user_info = UserInfo(available_slots=42, subscription_expiry=100)
+    assert user_db_manager.store_user(user_pk, user_info.to_dict()) is False
 
     # Same for wrong types
-    assert user_db_manager.store_user(42, user_data) is False
+    assert user_db_manager.store_user(42, user_info.to_dict()) is False
 
     # And for wrong type user data
     assert user_db_manager.store_user(user_pk, 42) is False
@@ -71,9 +71,9 @@ def test_load_all_users(user_db_manager):
     # Adding some and checking we get them all
     for i in range(10):
         user_pk = "02" + get_random_value_hex(32)
-        user_data = {"available_slots": i}
-        user_db_manager.store_user(user_pk, user_data)
-        stored_users[user_pk] = user_data
+        user_info = UserInfo(available_slots=42, subscription_expiry=100)
+        user_db_manager.store_user(user_pk, user_info.to_dict())
+        stored_users[user_pk] = user_info.to_dict()
 
     all_users = user_db_manager.load_all_users()
 

--- a/test/teos/unit/test_watcher.py
+++ b/test/teos/unit/test_watcher.py
@@ -4,20 +4,21 @@ from shutil import rmtree
 from threading import Thread
 from coincurve import PrivateKey
 
-from teos import LOG_PREFIX
 from teos.carrier import Carrier
-from teos.watcher import Watcher
 from teos.tools import bitcoin_cli
 from teos.responder import Responder
+from teos.gatekeeper import UserInfo
+from teos.gatekeeper import Gatekeeper
 from teos.chain_monitor import ChainMonitor
 from teos.appointments_dbm import AppointmentsDBM
 from teos.block_processor import BlockProcessor
+from teos.watcher import Watcher, AppointmentLimitReached
 
 from common.tools import compute_locator
 from common.cryptographer import Cryptographer
 
 from test.teos.unit.conftest import (
-    generate_blocks,
+    generate_blocks_w_delay,
     generate_dummy_appointment,
     get_random_value_hex,
     generate_keypair,
@@ -27,8 +28,6 @@ from test.teos.unit.conftest import (
 )
 
 APPOINTMENTS = 5
-START_TIME_OFFSET = 1
-END_TIME_OFFSET = 1
 TEST_SET_SIZE = 200
 
 config = get_config()
@@ -51,14 +50,12 @@ def temp_db_manager():
 
 
 @pytest.fixture(scope="module")
-def watcher(db_manager):
+def watcher(db_manager, gatekeeper):
     block_processor = BlockProcessor(bitcoind_connect_params)
     carrier = Carrier(bitcoind_connect_params)
 
-    responder = Responder(db_manager, carrier, block_processor)
-    watcher = Watcher(
-        db_manager, block_processor, responder, signing_key.to_der(), MAX_APPOINTMENTS, config.get("EXPIRY_DELTA")
-    )
+    responder = Responder(db_manager, gatekeeper, carrier, block_processor)
+    watcher = Watcher(db_manager, gatekeeper, block_processor, responder, signing_key.to_der(), MAX_APPOINTMENTS)
 
     chain_monitor = ChainMonitor(
         watcher.block_queue, watcher.responder.block_queue, block_processor, bitcoind_feed_params
@@ -84,9 +81,7 @@ def create_appointments(n):
     dispute_txs = []
 
     for i in range(n):
-        appointment, dispute_tx = generate_dummy_appointment(
-            start_time_offset=START_TIME_OFFSET, end_time_offset=END_TIME_OFFSET
-        )
+        appointment, dispute_tx = generate_dummy_appointment()
         uuid = uuid4().hex
 
         appointments[uuid] = appointment
@@ -103,82 +98,79 @@ def test_init(run_bitcoind, watcher):
     assert isinstance(watcher.block_processor, BlockProcessor)
     assert isinstance(watcher.responder, Responder)
     assert isinstance(watcher.max_appointments, int)
-    assert isinstance(watcher.expiry_delta, int)
+    assert isinstance(watcher.gatekeeper, Gatekeeper)
     assert isinstance(watcher.signing_key, PrivateKey)
 
 
-def test_get_appointment_summary(watcher):
-    # get_appointment_summary returns an appointment summary if found, else None.
-    random_uuid = get_random_value_hex(16)
-    appointment_summary = {"locator": get_random_value_hex(16), "end_time": 10, "size": 200}
-    watcher.appointments[random_uuid] = appointment_summary
-    assert watcher.get_appointment_summary(random_uuid) == appointment_summary
-
-    # Requesting a non-existing appointment
-    assert watcher.get_appointment_summary(get_random_value_hex(16)) is None
-
-
 def test_add_appointment(watcher):
-    # We should be able to add appointments up to the limit
-    for _ in range(10):
-        appointment, dispute_tx = generate_dummy_appointment(
-            start_time_offset=START_TIME_OFFSET, end_time_offset=END_TIME_OFFSET
-        )
-        user_pk = get_random_value_hex(33)
+    # Simulate the user is registered
+    user_sk, user_pk = generate_keypair()
+    available_slots = 100
+    user_id = Cryptographer.get_compressed_pk(user_pk)
+    watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=available_slots, subscription_expiry=10)
 
-        added_appointment, sig = watcher.add_appointment(appointment, user_pk)
+    appointment, dispute_tx = generate_dummy_appointment()
+    appointment_signature = Cryptographer.sign(appointment.serialize(), user_sk)
 
-        assert added_appointment is True
-        assert Cryptographer.get_compressed_pk(watcher.signing_key.public_key) == Cryptographer.get_compressed_pk(
-            Cryptographer.recover_pk(appointment.serialize(), sig)
-        )
+    response = watcher.add_appointment(appointment, appointment_signature)
+    assert response.get("locator") == appointment.locator
+    assert Cryptographer.get_compressed_pk(watcher.signing_key.public_key) == Cryptographer.get_compressed_pk(
+        Cryptographer.recover_pk(appointment.serialize(), response.get("signature"))
+    )
+    assert response.get("available_slots") == available_slots - 1
 
-        # Check that we can also add an already added appointment (same locator)
-        added_appointment, sig = watcher.add_appointment(appointment, user_pk)
+    # Check that we can also add an already added appointment (same locator)
+    response = watcher.add_appointment(appointment, appointment_signature)
+    assert response.get("locator") == appointment.locator
+    assert Cryptographer.get_compressed_pk(watcher.signing_key.public_key) == Cryptographer.get_compressed_pk(
+        Cryptographer.recover_pk(appointment.serialize(), response.get("signature"))
+    )
+    # The slot count should not have been reduced and only one copy is kept.
+    assert response.get("available_slots") == available_slots - 1
+    assert len(watcher.locator_uuid_map[appointment.locator]) == 1
 
-        assert added_appointment is True
-        assert Cryptographer.get_compressed_pk(watcher.signing_key.public_key) == Cryptographer.get_compressed_pk(
-            Cryptographer.recover_pk(appointment.serialize(), sig)
-        )
+    # If two appointments with the same locator come from different users, they are kept.
+    another_user_sk, another_user_pk = generate_keypair()
+    another_user_id = Cryptographer.get_compressed_pk(another_user_pk)
+    watcher.gatekeeper.registered_users[another_user_id] = UserInfo(
+        available_slots=available_slots, subscription_expiry=10
+    )
 
-        # If two appointments with the same locator from the same user are added, they are overwritten, but if they come
-        # from different users, they are kept.
-        assert len(watcher.locator_uuid_map[appointment.locator]) == 1
-
-        different_user_pk = get_random_value_hex(33)
-        added_appointment, sig = watcher.add_appointment(appointment, different_user_pk)
-        assert added_appointment is True
-        assert Cryptographer.get_compressed_pk(watcher.signing_key.public_key) == Cryptographer.get_compressed_pk(
-            Cryptographer.recover_pk(appointment.serialize(), sig)
-        )
-        assert len(watcher.locator_uuid_map[appointment.locator]) == 2
+    appointment_signature = Cryptographer.sign(appointment.serialize(), another_user_sk)
+    response = watcher.add_appointment(appointment, appointment_signature)
+    assert response.get("locator") == appointment.locator
+    assert Cryptographer.get_compressed_pk(watcher.signing_key.public_key) == Cryptographer.get_compressed_pk(
+        Cryptographer.recover_pk(appointment.serialize(), response.get("signature"))
+    )
+    assert response.get("available_slots") == available_slots - 1
+    assert len(watcher.locator_uuid_map[appointment.locator]) == 2
 
 
 def test_add_too_many_appointments(watcher):
-    # Any appointment on top of those should fail
+    # Simulate the user is registered
+    user_sk, user_pk = generate_keypair()
+    available_slots = 100
+    user_id = Cryptographer.get_compressed_pk(user_pk)
+    watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=available_slots, subscription_expiry=10)
+
+    # Appointments on top of the limit should be rejected
     watcher.appointments = dict()
 
-    for _ in range(MAX_APPOINTMENTS):
-        appointment, dispute_tx = generate_dummy_appointment(
-            start_time_offset=START_TIME_OFFSET, end_time_offset=END_TIME_OFFSET
-        )
-        user_pk = get_random_value_hex(33)
+    for i in range(MAX_APPOINTMENTS):
+        appointment, dispute_tx = generate_dummy_appointment()
+        appointment_signature = Cryptographer.sign(appointment.serialize(), user_sk)
 
-        added_appointment, sig = watcher.add_appointment(appointment, user_pk)
-
-        assert added_appointment is True
+        response = watcher.add_appointment(appointment, appointment_signature)
+        assert response.get("locator") == appointment.locator
         assert Cryptographer.get_compressed_pk(watcher.signing_key.public_key) == Cryptographer.get_compressed_pk(
-            Cryptographer.recover_pk(appointment.serialize(), sig)
+            Cryptographer.recover_pk(appointment.serialize(), response.get("signature"))
         )
+        assert response.get("available_slots") == available_slots - (i + 1)
 
-    appointment, dispute_tx = generate_dummy_appointment(
-        start_time_offset=START_TIME_OFFSET, end_time_offset=END_TIME_OFFSET
-    )
-    user_pk = get_random_value_hex(33)
-    added_appointment, sig = watcher.add_appointment(appointment, user_pk)
-
-    assert added_appointment is False
-    assert sig is None
+    with pytest.raises(AppointmentLimitReached):
+        appointment, dispute_tx = generate_dummy_appointment()
+        appointment_signature = Cryptographer.sign(appointment.serialize(), user_sk)
+        watcher.add_appointment(appointment, appointment_signature)
 
 
 def test_do_watch(watcher, temp_db_manager):
@@ -190,9 +182,18 @@ def test_do_watch(watcher, temp_db_manager):
     # Set the data into the Watcher and in the db
     watcher.locator_uuid_map = locator_uuid_map
     watcher.appointments = {}
+    watcher.gatekeeper.registered_users = {}
 
+    # Simulate a register
+    user_id = get_random_value_hex(16)
+    watcher.gatekeeper.registered_users[user_id] = UserInfo(
+        available_slots=100, subscription_expiry=watcher.block_processor.get_block_count() + 10
+    )
+
+    # Add the appointments
     for uuid, appointment in appointments.items():
-        watcher.appointments[uuid] = {"locator": appointment.locator, "end_time": appointment.end_time, "size": 200}
+        watcher.appointments[uuid] = {"locator": appointment.locator, "user_id": user_id, "size": 200}
+        watcher.gatekeeper.registered_users[user_id].appointments.append(uuid)
         watcher.db_manager.store_watcher_appointment(uuid, appointment.to_dict())
         watcher.db_manager.create_append_locator_map(appointment.locator, uuid)
 
@@ -203,14 +204,14 @@ def test_do_watch(watcher, temp_db_manager):
     for dispute_tx in dispute_txs[:2]:
         bitcoin_cli(bitcoind_connect_params).sendrawtransaction(dispute_tx)
 
-    # After generating enough blocks, the number of appointments should have reduced by two
-    generate_blocks(START_TIME_OFFSET + END_TIME_OFFSET)
+    # After generating a block, the appointment count should have been reduced by 2 (two breaches)
+    generate_blocks_w_delay(1)
 
     assert len(watcher.appointments) == APPOINTMENTS - 2
 
-    # The rest of appointments will timeout after the end (2) + EXPIRY_DELTA
+    # The rest of appointments will timeout after the subscription times-out (9 more blocks) + EXPIRY_DELTA
     # Wait for an additional block to be safe
-    generate_blocks(config.get("EXPIRY_DELTA") + START_TIME_OFFSET + END_TIME_OFFSET)
+    generate_blocks_w_delay(10 + config.get("EXPIRY_DELTA"))
 
     assert len(watcher.appointments) == 0
 
@@ -242,7 +243,7 @@ def test_filter_valid_breaches_random_data(watcher):
     for i in range(TEST_SET_SIZE):
         dummy_appointment, _ = generate_dummy_appointment()
         uuid = uuid4().hex
-        appointments[uuid] = {"locator": dummy_appointment.locator, "end_time": dummy_appointment.end_time}
+        appointments[uuid] = {"locator": dummy_appointment.locator, "user_id": dummy_appointment.user_id}
         watcher.db_manager.store_watcher_appointment(uuid, dummy_appointment.to_dict())
         watcher.db_manager.create_append_locator_map(dummy_appointment.locator, uuid)
 
@@ -282,7 +283,7 @@ def test_filter_valid_breaches(watcher):
     breaches = {dummy_appointment.locator: dispute_txid}
 
     for uuid, appointment in appointments.items():
-        watcher.appointments[uuid] = {"locator": appointment.locator, "end_time": appointment.end_time}
+        watcher.appointments[uuid] = {"locator": appointment.locator, "user_id": appointment.user_id}
         watcher.db_manager.store_watcher_appointment(uuid, dummy_appointment.to_dict())
         watcher.db_manager.create_append_locator_map(dummy_appointment.locator, uuid)
 

--- a/watchtower-plugin/watchtower.py
+++ b/watchtower-plugin/watchtower.py
@@ -154,16 +154,9 @@ def get_appointment(plugin, *args):
 @plugin.hook("commitment_revocation")
 def add_appointment(plugin, **kwargs):
     try:
-        # FIXME: start_time and end_time are temporary. Fix it on the tower side and remove it from there
-        block_height = plugin.rpc.getchaininfo().get("blockcount")
-        start_time = block_height + 1
-        end_time = block_height + 10
-
         commitment_txid, penalty_tx = arg_parser.parse_add_appointment_arguments(kwargs)
         appointment = Appointment(
             locator=compute_locator(commitment_txid),
-            start_time=start_time,
-            end_time=end_time,
             to_self_delay=20,
             encrypted_blob=Cryptographer.encrypt(penalty_tx, commitment_txid),
         )


### PR DESCRIPTION
Appointment start and end times have been part of the appointment data from the very beginning on the codebase. This PR shift them to be part of the subscription, so all appointments of a subscription expire at the same time, and the user does not have care about start/end times when sending an appointment.

The subscriptions / user related data are kept by the `Gatekeeper`, while the appointment related data is kept by either the `Watcher` or the `Responder`. Historically, there has been no concept of user within the tower: once accepted, appointment were single entities to be watched. In the current approach, there is a link between users and appointments: the subscription (or expiry time).

Therefore, a `user_id` has been added to both the `Watcher` and `Responder`, as well as a copy of the `Gatekeeper`, so user data can be accessed / modified when needed. The only purpose of user data within the tower is to keep track of when the appointments expire.

List of major changes:

- Creates `UserInfo` within the `Gatekeeper`
- Adds `user_id` to both the appointment and tracker summary (`Watcher`/`Responder`)
- Removes the `Gatekeeper` from the `API` and moves it to the `Watcher` and `Responder`.
- Removes size from the appointment summary
- Adds `ExtendedAppointment` class as an `Appointment` with user information. `ExtendedAppointment` is used within the tower-side while `Appointment` is used within the user-side.
- Adds the concept of irrevocably resolved. Trackers that have made it to a block are only deleted once irrevocably resolved (100 confirmations). Appointments/Trackers that are not triggered or do not make it to a block are deleted upon expiring.


List of minor changes:
- cli -> user when referring to the user
- compressed_pk -> user_id
- Properly formats 404 responses in the API (some of them had no json content)
- Docstrings / typos