### PR TITLE
Updates the serialisation format for appointment signatures

### DIFF
--- a/cli/teos_cli.py
+++ b/cli/teos_cli.py
@@ -75,13 +75,13 @@ def create_appointment(appointment_data):
     tx = appointment_data.get("tx")
 
     if not tx_id:
-        raise InvalidParameter("Missing txid, locator cannot be computed")
+        raise InvalidParameter("Missing tx_id, locator cannot be computed")
     elif not is_256b_hex_str(tx_id):
-        raise InvalidParameter("Wrong txid, locator cannot be computed")
+        raise InvalidParameter("Wrong tx_id, locator cannot be computed")
     elif not tx:
-        raise InvalidParameter("The provided data is missing the transaction")
+        raise InvalidParameter("The tx field is missing in the provided data")
     elif not isinstance(tx, str):
-        raise InvalidParameter("The provided transaction is not a string")
+        raise InvalidParameter("The provided tx field is not a string")
 
     appointment_data["locator"] = compute_locator(tx_id)
     appointment_data["encrypted_blob"] = Cryptographer.encrypt(tx, tx_id)

--- a/cli/teos_cli.py
+++ b/cli/teos_cli.py
@@ -57,55 +57,65 @@ def register(user_id, teos_url):
     return response
 
 
-def add_appointment(appointment_data, user_sk, teos_id, teos_url):
+def create_appointment(appointment_data):
+    """
+    Creates an appointment object from an appointment data dictionary provided by the user. Performs all the required
+    sanity checks on the input data:
+        - Check that the given commitment_txid is correct (proper format and not missing)
+        - Check that the transaction is correct (not missing)
+
+    Args:
+        appointment_data (:obj:`dict`): a dictionary containing the appointment data.
+
+    Returns:
+        :obj:`common.appointment.Appointment`: An appointment built from the appointment data provided by the user.
+    """
+
+    tx_id = appointment_data.get("tx_id")
+    tx = appointment_data.get("tx")
+
+    if not tx_id:
+        raise InvalidParameter("Missing txid, locator cannot be computed")
+    elif not is_256b_hex_str(tx_id):
+        raise InvalidParameter("Wrong txid, locator cannot be computed")
+    elif not tx:
+        raise InvalidParameter("The provided data is missing the transaction")
+    elif not isinstance(tx, str):
+        raise InvalidParameter("The provided transaction is not a string")
+
+    appointment_data["locator"] = compute_locator(tx_id)
+    appointment_data["encrypted_blob"] = Cryptographer.encrypt(tx, tx_id)
+
+    return Appointment.from_dict(appointment_data)
+
+
+def add_appointment(appointment, user_sk, teos_id, teos_url):
     """
     Manages the add_appointment command.
 
     The life cycle of the function is as follows:
-        - Check that the given commitment_txid is correct (proper format and not missing)
-        - Check that the transaction is correct (not missing)
-        - Create the appointment locator and encrypted blob from the commitment_txid and the penalty_tx
         - Sign the appointment
         - Send the appointment to the tower
         - Wait for the response
         - Check the tower's response and signature
 
     Args:
-        appointment_data (:obj:`dict`): a dictionary containing the appointment data.
+        appointment (:obj:`Appointment <common.appointment.Appointment>`): An appointment object.
         user_sk (:obj:`PrivateKey`): the user's private key.
         teos_id (:obj:`str`): the tower's compressed public key.
         teos_url (:obj:`str`): the teos base url.
 
     Returns:
-        :obj:`tuple`: A tuple (`:obj:Appointment <common.appointment.Appointment>`, :obj:`str`) containing the
-        appointment and the tower's signature.
+        :obj:`tuple`: A tuple containing the start block and the tower's signature of the appointment.
 
     Raises:
-        :obj:`InvalidParameter <cli.exceptions.InvalidParameter>`: if `appointment_data` or any of its fields is
-        invalid.
         :obj:`ValueError`: if the appointment cannot be signed.
         :obj:`ConnectionError`: if the client cannot connect to the tower.
         :obj:`TowerResponseError <cli.exceptions.TowerResponseError>`: if the tower responded with an error, or the
         response was invalid.
     """
 
-    if not appointment_data:
-        raise InvalidParameter("The provided appointment JSON is empty")
-
-    tx_id = appointment_data.get("tx_id")
-    tx = appointment_data.get("tx")
-
-    if not is_256b_hex_str(tx_id):
-        raise InvalidParameter("The provided locator is wrong or missing")
-
-    if not tx:
-        raise InvalidParameter("The provided data is missing the transaction")
-
-    appointment_data["locator"] = compute_locator(tx_id)
-    appointment_data["encrypted_blob"] = Cryptographer.encrypt(tx, tx_id)
-    appointment = Appointment.from_dict(appointment_data)
     signature = Cryptographer.sign(appointment.serialize(), user_sk)
-
     data = {"appointment": appointment.to_dict(), "signature": signature}
 
     # Send appointment to the server.
@@ -114,19 +124,21 @@ def add_appointment(appointment_data, user_sk, teos_id, teos_url):
     response = process_post_response(post_request(data, add_appointment_endpoint))
 
     tower_signature = response.get("signature")
+    start_block = response.get("start_block")
+    appointment_receipt = Appointment.create_receipt(signature, start_block)
     # Check that the server signed the appointment as it should.
     if not tower_signature:
         raise TowerResponseError("The response does not contain the signature of the appointment")
 
-    rpk = Cryptographer.recover_pk(appointment.serialize(), tower_signature)
+    rpk = Cryptographer.recover_pk(appointment_receipt, tower_signature)
     if teos_id != Cryptographer.get_compressed_pk(rpk):
         raise TowerResponseError("The returned appointment's signature is invalid")
 
     logger.info("Appointment accepted and signed by the Eye of Satoshi")
     logger.info("Remaining slots: {}".format(response.get("available_slots")))
-    logger.info("Start block: {}".format(response.get("start_block")))
+    logger.info("Start block: {}".format(start_block))
 
-    return appointment, tower_signature
+    return start_block, tower_signature
 
 
 def get_appointment(locator, user_sk, teos_id, teos_url):
@@ -350,18 +362,22 @@ def parse_add_appointment_args(args):
         else:
             appointment_data = json.loads(arg_opt)
 
+        if not appointment_data:
+            raise InvalidParameter("The provided appointment JSON is empty")
+
     except json.JSONDecodeError:
         raise InvalidParameter("Non-JSON encoded data provided as appointment. " + use_help)
 
     return appointment_data
 
 
-def save_appointment_receipt(appointment, signature, appointments_folder_path):
+def save_appointment_receipt(appointment, start_block, signature, appointments_folder_path):
     """
     Saves an appointment receipt to disk. A receipt consists of an appointment and a signature from the tower.
 
     Args:
         appointment (:obj:`Appointment <common.appointment.Appointment>`): the appointment to be saved on disk.
+        start_block (:obj:`int`): the block height at which the tower started to watch for the appointment.
         signature (:obj:`str`): the signature of the appointment performed by the tower.
         appointments_folder_path (:obj:`str`): the path to the appointments folder.
 
@@ -377,7 +393,7 @@ def save_appointment_receipt(appointment, signature, appointments_folder_path):
     uuid = uuid4().hex  # prevent filename collisions
 
     filename = "{}/appointment-{}-{}-{}.json".format(appointments_folder_path, timestamp, locator, uuid)
-    data = {"appointment": appointment, "signature": signature}
+    data = {"appointment": appointment, "start_block": start_block, "signature": signature}
 
     try:
         with open(filename, "w") as f:
@@ -411,8 +427,11 @@ def main(command, args, command_line_conf):
 
         if command == "add_appointment":
             appointment_data = parse_add_appointment_args(args)
-            appointment, signature = add_appointment(appointment_data, user_sk, teos_id, teos_url)
-            save_appointment_receipt(appointment.to_dict(), signature, config.get("APPOINTMENTS_FOLDER_NAME"))
+            appointment = create_appointment(appointment_data)
+            start_block, signature = add_appointment(appointment, user_sk, teos_id, teos_url)
+            save_appointment_receipt(
+                appointment.to_dict(), start_block, signature, config.get("APPOINTMENTS_FOLDER_NAME")
+            )
 
         elif command == "get_appointment":
             if not args:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,5 @@ pytest
 black
 flake8
 responses
-bitcoind_mock===0.0.4
+bitcoind_mock===0.0.5
 

--- a/teos/api.py
+++ b/teos/api.py
@@ -10,6 +10,7 @@ from teos.gatekeeper import NotEnoughSlots, AuthenticationFailure
 
 from common.logger import Logger
 from common.cryptographer import hash_160
+from common.appointment import Appointment
 from common.exceptions import InvalidParameter
 from common.constants import HTTP_OK, HTTP_BAD_REQUEST, HTTP_SERVICE_UNAVAILABLE, HTTP_NOT_FOUND
 
@@ -245,7 +246,7 @@ class API:
             triggered_appointments = self.watcher.db_manager.load_all_triggered_flags()
             uuid = hash_160("{}{}".format(locator, user_id))
 
-            # If the appointment has been triggered, it should be in the locator (default else just in case).
+            # If the appointment has been triggered, it should be in the Responder (default else just in case).
             if uuid in triggered_appointments:
                 appointment_data = self.watcher.db_manager.load_responder_tracker(uuid)
                 if appointment_data:
@@ -262,8 +263,8 @@ class API:
                 appointment_data = self.watcher.db_manager.load_watcher_appointment(uuid)
                 if appointment_data:
                     rcode = HTTP_OK
-                    # Remove user_id field from appointment data since it is an internal field
-                    appointment_data.pop("user_id")
+                    # Remove the unnecessary data by casting the extended appointment to a regular appointment
+                    appointment_data = Appointment.from_dict(appointment_data).to_dict()
                     response = {"locator": locator, "status": "being_watched", "appointment": appointment_data}
                 else:
                     rcode = HTTP_NOT_FOUND
@@ -279,7 +280,7 @@ class API:
         """
         Gives information about all the appointments in the Watchtower.
 
-        This endpoint should only be accessible by the administrator. Requests are only allowed from localhost.
+          This endpoint should only be accessible by the administrator. Requests are only allowed from localhost.
 
         Returns:
             :obj:`str`: A json formatted dictionary containing all the appointments hold by the ``Watcher``

--- a/teos/extended_appointment.py
+++ b/teos/extended_appointment.py
@@ -5,8 +5,8 @@ class ExtendedAppointment(Appointment):
     """
     The :class:`ExtendedAppointment` contains extended information about an appointment between a user and the tower.
 
-    While it shares some information with an :class:`Appointment <common.appointment.Appointment>`, it also
-    includes information relevant to the tower, such as the ``user_id``, ``user_signature`` and ``start_block``.
+    It extends the :class:`Appointment <common.appointment.Appointment>` with information relevant to the tower, such
+    as the ``user_id``, ``user_signature`` and ``start_block``.
 
     Args:
         locator (:obj:`str`): A 16-byte hex-encoded value used by the tower to detect channel breaches. It serves as a

--- a/teos/extended_appointment.py
+++ b/teos/extended_appointment.py
@@ -2,13 +2,33 @@ from common.appointment import Appointment
 
 
 class ExtendedAppointment(Appointment):
-    def __init__(self, locator, to_self_delay, encrypted_blob, user_id):
-        super().__init__(locator, to_self_delay, encrypted_blob)
+    """
+    The :class:`ExtendedAppointment` contains extended information about an appointment between a user and the tower.
+
+    While it shares some information with an :class:`Appointment <common.appointment.Appointment>`, it also
+    includes information relevant to the tower, such as the ``user_id``, ``user_signature`` and ``start_block``.
+
+    Args:
+        locator (:obj:`str`): A 16-byte hex-encoded value used by the tower to detect channel breaches. It serves as a
+            trigger for the tower to decrypt and broadcast the penalty transaction.
+        encrypted_blob (:obj:`str`): An encrypted blob of data containing a penalty transaction. The tower will decrypt
+            it and broadcast the penalty transaction upon seeing a breach on the blockchain.
+        to_self_delay (:obj:`int`): The ``to_self_delay`` encoded in the ``csv`` of the ``to_remote`` output of the
+            commitment transaction that this appointment is covering.
+        user_id (:obj:`str`): the public key that identifies the user (33-bytes hex str).
+        user_signature (:obj:`str`): the signature of the appointment by the user.
+        start_block (:obj:`str`): the block height at where the towers started watching for this appointment.
+    """
+
+    def __init__(self, locator, encrypted_blob, to_self_delay, user_id, user_signature, start_block):
+        super().__init__(locator, encrypted_blob, to_self_delay)
         self.user_id = user_id
+        self.user_signature = user_signature
+        self.start_block = start_block
 
     def get_summary(self):
         """
-        Returns the summary of an appointment, consisting on the locator, the user_id and the appointment size.
+        Returns the summary of an appointment, consisting on the locator, and the user_id.
 
         Returns:
             :obj:`dict`: the appointment summary.
@@ -36,11 +56,20 @@ class ExtendedAppointment(Appointment):
 
         appointment = Appointment.from_dict(appointment_data)
         user_id = appointment_data.get("user_id")
+        user_signature = appointment_data.get("user_signature")
+        start_block = appointment_data.get("start_block")
 
-        if not user_id:
-            raise ValueError("Wrong appointment data, user_id is missing")
+        if any(v is None for v in [user_id, user_signature, start_block]):
+            raise ValueError("Wrong appointment data, some fields are missing")
 
         else:
-            appointment = cls(appointment.locator, appointment.to_self_delay, appointment.encrypted_blob, user_id)
+            appointment = cls(
+                appointment.locator,
+                appointment.encrypted_blob,
+                appointment.to_self_delay,
+                user_id,
+                user_signature,
+                start_block,
+            )
 
         return appointment

--- a/teos/inspector.py
+++ b/teos/inspector.py
@@ -1,12 +1,13 @@
 import re
 
+from common import errors
 from common.logger import Logger
 from common.tools import is_locator
+from common.appointment import Appointment
 from common.constants import LOCATOR_LEN_HEX
 
 from teos import LOG_PREFIX
-from common import errors
-from teos.extended_appointment import ExtendedAppointment
+
 
 logger = Logger(actor="Inspector", log_name_prefix=LOG_PREFIX)
 
@@ -49,8 +50,7 @@ class Inspector:
             appointment_data (:obj:`dict`): a dictionary containing the appointment data.
 
         Returns:
-            :obj:`Extended <teos.extended_appointment.ExtendedAppointment>`: An appointment initialized with
-            the provided data.
+            :obj:`Appointment <common.appointment.Appointment>`: An appointment initialized with the provided data.
 
         Raises:
            :obj:`InspectionFailed`: if any of the fields is wrong.
@@ -69,12 +69,10 @@ class Inspector:
         self.check_to_self_delay(appointment_data.get("to_self_delay"))
         self.check_blob(appointment_data.get("encrypted_blob"))
 
-        # Set user_id to None since we still don't know it, it'll be set by the API after querying the gatekeeper
-        return ExtendedAppointment(
+        return Appointment(
             appointment_data.get("locator"),
-            appointment_data.get("to_self_delay"),
             appointment_data.get("encrypted_blob"),
-            user_id=None,
+            appointment_data.get("to_self_delay"),
         )
 
     @staticmethod

--- a/test/cli/unit/test_teos_cli.py
+++ b/test/cli/unit/test_teos_cli.py
@@ -80,13 +80,13 @@ def test_create_appointment_missing_fields():
     incorrect_txid = {"tx_id": get_random_value_hex(31), "tx": get_random_value_hex(200)}
     incorrect_tx = {"tx_id": get_random_value_hex(32), "tx": 1}
 
-    with pytest.raises(InvalidParameter, match="Missing txid"):
+    with pytest.raises(InvalidParameter, match="Missing tx_id"):
         teos_cli.create_appointment(no_txid)
-    with pytest.raises(InvalidParameter, match="Wrong txid"):
+    with pytest.raises(InvalidParameter, match="Wrong tx_id"):
         teos_cli.create_appointment(incorrect_txid)
-    with pytest.raises(InvalidParameter, match="is missing the transaction"):
+    with pytest.raises(InvalidParameter, match="tx field is missing"):
         teos_cli.create_appointment(no_tx)
-    with pytest.raises(InvalidParameter, match="transaction is not a string"):
+    with pytest.raises(InvalidParameter, match="tx field is not a string"):
         teos_cli.create_appointment(incorrect_tx)
 
 
@@ -179,7 +179,7 @@ def test_load_keys():
     with open(empty_file_path, "wb"):
         pass
 
-    # Now we can test the function using this files
+    # Now we can test the function using these files
     r = teos_cli.load_keys(public_key_file_path, private_key_file_path)
     assert isinstance(r, tuple)
     assert len(r) == 3

--- a/test/cli/unit/test_teos_cli.py
+++ b/test/cli/unit/test_teos_cli.py
@@ -31,19 +31,11 @@ register_endpoint = "{}/register".format(teos_url)
 get_appointment_endpoint = "{}/get_appointment".format(teos_url)
 get_all_appointments_endpoint = "{}/get_all_appointments".format(teos_url)
 
-dummy_appointment_data = {
-    "tx": get_random_value_hex(192),
-    "tx_id": get_random_value_hex(32),
-    "start_time": 1500,
-    "end_time": 50000,
-    "to_self_delay": 200,
-}
+dummy_appointment_data = {"tx": get_random_value_hex(192), "tx_id": get_random_value_hex(32), "to_self_delay": 200}
 
 # This is the format appointment turns into once it hits "add_appointment"
 dummy_appointment_dict = {
     "locator": compute_locator(dummy_appointment_data.get("tx_id")),
-    "start_time": dummy_appointment_data.get("start_time"),
-    "end_time": dummy_appointment_data.get("end_time"),
     "to_self_delay": dummy_appointment_data.get("to_self_delay"),
     "encrypted_blob": Cryptographer.encrypt(dummy_appointment_data.get("tx"), dummy_appointment_data.get("tx_id")),
 }

--- a/test/common/unit/test_appointment.py
+++ b/test/common/unit/test_appointment.py
@@ -31,7 +31,7 @@ def test_init_appointment(appointment_data):
     # The appointment has no checks whatsoever, since the inspector is the one taking care or that, and the only one
     # creating appointments.
     appointment = Appointment(
-        appointment_data["locator"], appointment_data["to_self_delay"], appointment_data["encrypted_blob"]
+        appointment_data["locator"], appointment_data["encrypted_blob"], appointment_data["to_self_delay"]
     )
 
     assert (
@@ -43,7 +43,7 @@ def test_init_appointment(appointment_data):
 
 def test_to_dict(appointment_data):
     appointment = Appointment(
-        appointment_data["locator"], appointment_data["to_self_delay"], appointment_data["encrypted_blob"]
+        appointment_data["locator"], appointment_data["encrypted_blob"], appointment_data["to_self_delay"]
     )
 
     dict_appointment = appointment.to_dict()
@@ -82,9 +82,9 @@ def test_serialize(appointment_data):
     assert isinstance(serialized_appointment, bytes)
 
     locator = serialized_appointment[:16]
-    to_self_delay = serialized_appointment[16:20]
-    encrypted_blob = serialized_appointment[20:]
+    encrypted_blob = serialized_appointment[16:-4]
+    to_self_delay = serialized_appointment[-4:]
 
     assert binascii.hexlify(locator).decode() == appointment.locator
-    assert struct.unpack(">I", to_self_delay)[0] == appointment.to_self_delay
     assert binascii.hexlify(encrypted_blob).decode() == appointment.encrypted_blob
+    assert struct.unpack(">I", to_self_delay)[0] == appointment.to_self_delay

--- a/test/teos/e2e/test_basic_e2e.py
+++ b/test/teos/e2e/test_basic_e2e.py
@@ -73,7 +73,8 @@ def test_commands_non_registered(bitcoin_cli):
     appointment_data = build_appointment_data(commitment_tx_id, penalty_tx)
 
     with pytest.raises(TowerResponseError):
-        assert add_appointment(appointment_data)
+        appointment = teos_cli.create_appointment(appointment_data)
+        add_appointment(appointment)
 
     # Get appointment
     with pytest.raises(TowerResponseError):
@@ -91,8 +92,8 @@ def test_commands_registered(bitcoin_cli):
     commitment_tx_id = bitcoin_cli.decoderawtransaction(commitment_tx).get("txid")
     appointment_data = build_appointment_data(commitment_tx_id, penalty_tx)
 
-    appointment, available_slots = add_appointment(appointment_data)
-    assert isinstance(appointment, Appointment) and isinstance(available_slots, str)
+    appointment = teos_cli.create_appointment(appointment_data)
+    add_appointment(appointment)
 
     # Get appointment
     r = get_appointment_info(appointment_data.get("locator"))
@@ -113,7 +114,8 @@ def test_appointment_life_cycle(bitcoin_cli):
     commitment_tx_id = bitcoin_cli.decoderawtransaction(commitment_tx).get("txid")
     appointment_data = build_appointment_data(commitment_tx_id, penalty_tx)
     locator = compute_locator(commitment_tx_id)
-    appointment, signature = add_appointment(appointment_data)
+    appointment = teos_cli.create_appointment(appointment_data)
+    add_appointment(appointment)
     appointments_in_watcher += 1
 
     # Get the information from the tower to check that it matches
@@ -199,7 +201,8 @@ def test_multiple_appointments_life_cycle(bitcoin_cli):
 
     # Send all of them to watchtower.
     for appt in appointments:
-        add_appointment(appt.get("appointment_data"))
+        appointment = teos_cli.create_appointment(appt.get("appointment_data"))
+        add_appointment(appointment)
         appointments_in_watcher += 1
 
     # Two of these appointments are breached, and the watchtower responds to them.
@@ -244,7 +247,8 @@ def test_appointment_malformed_penalty(bitcoin_cli):
     appointment_data = build_appointment_data(commitment_tx_id, mod_penalty_tx.hex())
     locator = compute_locator(commitment_tx_id)
 
-    appointment, _ = add_appointment(appointment_data)
+    appointment = teos_cli.create_appointment(appointment_data)
+    add_appointment(appointment)
 
     # Get the information from the tower to check that it matches
     appointment_info = get_appointment_info(locator)
@@ -309,8 +313,9 @@ def test_two_identical_appointments(bitcoin_cli):
     locator = compute_locator(commitment_tx_id)
 
     # Send the appointment twice
-    add_appointment(appointment_data)
-    add_appointment(appointment_data)
+    appointment = teos_cli.create_appointment(appointment_data)
+    add_appointment(appointment)
+    add_appointment(appointment)
 
     # Broadcast the commitment transaction and mine a block
     new_addr = bitcoin_cli.getnewaddress()
@@ -372,7 +377,7 @@ def test_two_identical_appointments(bitcoin_cli):
 
 
 def test_two_appointment_same_locator_different_penalty_different_users(bitcoin_cli):
-    # This tests sending an appointment with two valid transaction with the same locator fro different users
+    # This tests sending an appointment with two valid transaction with the same locator from different users
     commitment_tx, penalty_tx1 = create_txs(bitcoin_cli)
     commitment_tx_id = bitcoin_cli.decoderawtransaction(commitment_tx).get("txid")
 
@@ -390,8 +395,10 @@ def test_two_appointment_same_locator_different_penalty_different_users(bitcoin_
     tmp_user_id = hexlify(tmp_user_sk.public_key.format(compressed=True)).decode("utf-8")
     teos_cli.register(tmp_user_id, teos_base_endpoint)
 
-    appointment, _ = add_appointment(appointment1_data)
-    appointment_2, _ = add_appointment(appointment2_data, sk=tmp_user_sk)
+    appointment_1 = teos_cli.create_appointment(appointment1_data)
+    add_appointment(appointment_1)
+    appointment_2 = teos_cli.create_appointment(appointment2_data)
+    add_appointment(appointment_2, sk=tmp_user_sk)
 
     # Broadcast the commitment transaction and mine a block
     new_addr = bitcoin_cli.getnewaddress()
@@ -424,7 +431,8 @@ def test_add_appointment_trigger_on_cache(bitcoin_cli):
     broadcast_transaction_and_mine_block(bitcoin_cli, commitment_tx, bitcoin_cli.getnewaddress())
 
     # Send the data to the tower and request it back. It should have gone straightaway to the Responder
-    add_appointment(appointment_data)
+    appointment = teos_cli.create_appointment(appointment_data)
+    add_appointment(appointment)
     assert get_appointment_info(locator).get("status") == "dispute_responded"
 
 
@@ -442,7 +450,8 @@ def test_add_appointment_invalid_trigger_on_cache(bitcoin_cli):
     sleep(1)
 
     # Send the data to the tower and request it back. It should get accepted but the data will be dropped.
-    add_appointment(appointment_data)
+    appointment = teos_cli.create_appointment(appointment_data)
+    add_appointment(appointment)
     with pytest.raises(TowerResponseError):
         get_appointment_info(locator)
 
@@ -482,6 +491,8 @@ def test_add_appointment_trigger_on_cache_cannot_decrypt(bitcoin_cli):
 
 
 def test_appointment_shutdown_teos_trigger_back_online(bitcoin_cli):
+    # This tests data persistence. An appointment is sent to the tower, the tower is restarted and the appointment is
+    # then triggered.
     global teosd_process
 
     teos_pid = teosd_process.pid
@@ -491,7 +502,8 @@ def test_appointment_shutdown_teos_trigger_back_online(bitcoin_cli):
     appointment_data = build_appointment_data(commitment_tx_id, penalty_tx)
     locator = compute_locator(commitment_tx_id)
 
-    appointment, _ = add_appointment(appointment_data)
+    appointment = teos_cli.create_appointment(appointment_data)
+    add_appointment(appointment)
 
     # Restart teos
     teosd_process.terminate()
@@ -515,6 +527,8 @@ def test_appointment_shutdown_teos_trigger_back_online(bitcoin_cli):
 
 
 def test_appointment_shutdown_teos_trigger_while_offline(bitcoin_cli):
+    # This tests data persistence. An appointment is sent to the tower and the tower is stopped. The appointment is then
+    # triggered with the tower offline, and then the tower is brought back online.
     global teosd_process
 
     teos_pid = teosd_process.pid
@@ -524,7 +538,8 @@ def test_appointment_shutdown_teos_trigger_while_offline(bitcoin_cli):
     appointment_data = build_appointment_data(commitment_tx_id, penalty_tx)
     locator = compute_locator(commitment_tx_id)
 
-    appointment, _ = add_appointment(appointment_data)
+    appointment = teos_cli.create_appointment(appointment_data)
+    add_appointment(appointment)
 
     # Check that the appointment is still in the Watcher
     appointment_info = get_appointment_info(locator)

--- a/test/teos/e2e/test_basic_e2e.py
+++ b/test/teos/e2e/test_basic_e2e.py
@@ -283,8 +283,9 @@ def test_appointment_wrong_decryption_key(bitcoin_cli):
     response_json = teos_cli.process_post_response(response)
 
     # Check that the server has accepted the appointment
-    signature = response_json.get("signature")
-    rpk = Cryptographer.recover_pk(appointment.serialize(), signature)
+    tower_signature = response_json.get("signature")
+    appointment_receipt = Appointment.create_receipt(signature, response_json.get("start_block"))
+    rpk = Cryptographer.recover_pk(appointment_receipt, tower_signature)
     assert teos_id == Cryptographer.get_compressed_pk(rpk)
     assert response_json.get("locator") == appointment.locator
 
@@ -469,12 +470,13 @@ def test_add_appointment_trigger_on_cache_cannot_decrypt(bitcoin_cli):
     response_json = teos_cli.process_post_response(response)
 
     # Check that the server has accepted the appointment
-    signature = response_json.get("signature")
-    rpk = Cryptographer.recover_pk(appointment.serialize(), signature)
+    tower_signature = response_json.get("signature")
+    appointment_receipt = Appointment.create_receipt(signature, response_json.get("start_block"))
+    rpk = Cryptographer.recover_pk(appointment_receipt, tower_signature)
     assert teos_id == Cryptographer.get_compressed_pk(rpk)
     assert response_json.get("locator") == appointment.locator
 
-    # The appointment should should have been inmediately dropped
+    # The appointment should should have been immediately dropped
     with pytest.raises(TowerResponseError):
         get_appointment_info(appointment_data["locator"])
 

--- a/test/teos/unit/conftest.py
+++ b/test/teos/unit/conftest.py
@@ -142,6 +142,8 @@ def generate_dummy_appointment():
         "to_self_delay": dummy_appointment_data.get("to_self_delay"),
         "encrypted_blob": encrypted_blob,
         "user_id": get_random_value_hex(16),
+        "user_signature": get_random_value_hex(50),
+        "start_block": 200,
     }
 
     return ExtendedAppointment.from_dict(appointment_data), dispute_tx.hex()

--- a/test/teos/unit/test_api.py
+++ b/test/teos/unit/test_api.py
@@ -4,12 +4,12 @@ from binascii import hexlify
 
 from teos.api import API
 import common.errors as errors
+from teos.watcher import Watcher
 from teos.inspector import Inspector
 from teos.gatekeeper import UserInfo
+from common.appointment import Appointment
 from teos.appointments_dbm import AppointmentsDBM
 from teos.responder import Responder, TransactionTracker
-from teos.extended_appointment import ExtendedAppointment
-from teos.watcher import Watcher, AppointmentAlreadyTriggered
 
 from test.teos.unit.conftest import (
     get_random_value_hex,
@@ -77,6 +77,7 @@ def api(db_manager, carrier, block_processor, gatekeeper, run_bitcoind):
         MAX_APPOINTMENTS,
         config.get("LOCATOR_CACHE_SIZE"),
     )
+    watcher.last_known_block = block_processor.get_best_block_hash()
     inspector = Inspector(block_processor, config.get("MIN_TO_SELF_DELAY"))
     api = API(config.get("API_HOST"), config.get("API_PORT"), inspector, watcher)
 
@@ -164,7 +165,7 @@ def test_register_json_no_inner_dict(client):
     assert errors.INVALID_REQUEST_FORMAT == r.json.get("error_code")
 
 
-def test_add_appointment(api, client, appointment):
+def test_add_appointment(api, client, appointment, block_processor):
     # Simulate the user registration (end time does not matter here)
     api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=1, subscription_expiry=0)
 
@@ -173,7 +174,7 @@ def test_add_appointment(api, client, appointment):
     r = add_appointment(client, {"appointment": appointment.to_dict(), "signature": appointment_signature}, user_id)
     assert r.status_code == HTTP_OK
     assert r.json.get("available_slots") == 0
-    assert r.json.get("start_block") == api.watcher.last_known_block
+    assert r.json.get("start_block") == block_processor.get_block_count()
 
 
 def test_add_appointment_no_json(api, client, appointment):
@@ -249,7 +250,7 @@ def test_add_appointment_registered_not_enough_free_slots(api, client, appointme
     assert errors.APPOINTMENT_INVALID_SIGNATURE_OR_INSUFFICIENT_SLOTS == r.json.get("error_code")
 
 
-def test_add_appointment_multiple_times_same_user(api, client, appointment, n=MULTIPLE_APPOINTMENTS):
+def test_add_appointment_multiple_times_same_user(api, client, appointment, block_processor, n=MULTIPLE_APPOINTMENTS):
     # Multiple appointments with the same locator should be valid and count as updates
     appointment_signature = Cryptographer.sign(appointment.serialize(), user_sk)
 
@@ -259,13 +260,15 @@ def test_add_appointment_multiple_times_same_user(api, client, appointment, n=MU
         r = add_appointment(client, {"appointment": appointment.to_dict(), "signature": appointment_signature}, user_id)
         assert r.status_code == HTTP_OK
         assert r.json.get("available_slots") == n - 1
-        assert r.json.get("start_block") == api.watcher.last_known_block
+        assert r.json.get("start_block") == block_processor.get_block_count()
 
     # Since all updates came from the same user, only the last one is stored
     assert len(api.watcher.locator_uuid_map[appointment.locator]) == 1
 
 
-def test_add_appointment_multiple_times_different_users(api, client, appointment, n=MULTIPLE_APPOINTMENTS):
+def test_add_appointment_multiple_times_different_users(
+    api, client, appointment, block_processor, n=MULTIPLE_APPOINTMENTS
+):
     # If the same appointment comes from different users, all are kept
     # Create user keys and appointment signatures
     user_keys = [generate_keypair() for _ in range(n)]
@@ -282,13 +285,13 @@ def test_add_appointment_multiple_times_different_users(api, client, appointment
         r = add_appointment(client, {"appointment": appointment.to_dict(), "signature": signature}, compressed_pk)
         assert r.status_code == HTTP_OK
         assert r.json.get("available_slots") == 1
-        assert r.json.get("start_block") == api.watcher.last_known_block
+        assert r.json.get("start_block") == block_processor.get_block_count()
 
     # Check that all the appointments have been added and that there are no duplicates
     assert len(set(api.watcher.locator_uuid_map[appointment.locator])) == n
 
 
-def test_add_appointment_update_same_size(api, client, appointment):
+def test_add_appointment_update_same_size(api, client, appointment, block_processor):
     # Update an appointment by one of the same size and check that no additional slots are filled
     api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=1, subscription_expiry=0)
 
@@ -297,7 +300,7 @@ def test_add_appointment_update_same_size(api, client, appointment):
     assert (
         r.status_code == HTTP_OK
         and r.json.get("available_slots") == 0
-        and r.json.get("start_block") == api.watcher.last_known_block
+        and r.json.get("start_block") == block_processor.get_block_count()
     )
 
     # The user has no additional slots, but it should be able to update
@@ -308,11 +311,11 @@ def test_add_appointment_update_same_size(api, client, appointment):
     assert (
         r.status_code == HTTP_OK
         and r.json.get("available_slots") == 0
-        and r.json.get("start_block") == api.watcher.last_known_block
+        and r.json.get("start_block") == block_processor.get_block_count()
     )
 
 
-def test_add_appointment_update_bigger(api, client, appointment):
+def test_add_appointment_update_bigger(api, client, appointment, block_processor):
     # Update an appointment by one bigger, and check additional slots are filled
     api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=2, subscription_expiry=0)
 
@@ -327,7 +330,7 @@ def test_add_appointment_update_bigger(api, client, appointment):
     assert (
         r.status_code == HTTP_OK
         and r.json.get("available_slots") == 0
-        and r.json.get("start_block") == api.watcher.last_known_block
+        and r.json.get("start_block") == block_processor.get_block_count()
     )
 
     # Check that it'll fail if no enough slots are available
@@ -338,7 +341,7 @@ def test_add_appointment_update_bigger(api, client, appointment):
     assert r.status_code == HTTP_BAD_REQUEST
 
 
-def test_add_appointment_update_smaller(api, client, appointment):
+def test_add_appointment_update_smaller(api, client, appointment, block_processor):
     # Update an appointment by one bigger, and check slots are freed
     api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=2, subscription_expiry=0)
     # This should take 2 slots
@@ -348,7 +351,7 @@ def test_add_appointment_update_smaller(api, client, appointment):
     assert (
         r.status_code == HTTP_OK
         and r.json.get("available_slots") == 0
-        and r.json.get("start_block") == api.watcher.last_known_block
+        and r.json.get("start_block") == block_processor.get_block_count()
     )
 
     # Let's update with one just small enough
@@ -358,11 +361,11 @@ def test_add_appointment_update_smaller(api, client, appointment):
     assert (
         r.status_code == HTTP_OK
         and r.json.get("available_slots") == 1
-        and r.json.get("start_block") == api.watcher.last_known_block
+        and r.json.get("start_block") == block_processor.get_block_count()
     )
 
 
-def test_add_appointment_in_cache(api, client):
+def test_add_appointment_in_cache(api, client, block_processor):
     api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=1, subscription_expiry=0)
     appointment, dispute_tx = generate_dummy_appointment()
     appointment_signature = Cryptographer.sign(appointment.serialize(), user_sk)
@@ -375,7 +378,7 @@ def test_add_appointment_in_cache(api, client):
     assert (
         r.status_code == HTTP_OK
         and r.json.get("available_slots") == 0
-        and r.json.get("start_block") == api.watcher.last_known_block
+        and r.json.get("start_block") == block_processor.get_block_count()
     )
 
     # Trying to add it again should fail, since it is already in the Responder
@@ -388,7 +391,7 @@ def test_add_appointment_in_cache(api, client):
     assert r.status_code == HTTP_BAD_REQUEST and r.json.get("error_code") == errors.APPOINTMENT_ALREADY_TRIGGERED
 
 
-def test_add_appointment_in_cache_cannot_decrypt(api, client):
+def test_add_appointment_in_cache_cannot_decrypt(api, client, block_processor):
     api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=1, subscription_expiry=0)
     appointment, dispute_tx = generate_dummy_appointment()
     appointment.encrypted_blob = appointment.encrypted_blob[::-1]
@@ -403,11 +406,11 @@ def test_add_appointment_in_cache_cannot_decrypt(api, client):
     assert (
         r.status_code == HTTP_OK
         and r.json.get("available_slots") == 0
-        and r.json.get("start_block") == api.watcher.last_known_block
+        and r.json.get("start_block") == block_processor.get_block_count()
     )
 
 
-def test_add_appointment_in_cache_invalid_transaction(api, client):
+def test_add_appointment_in_cache_invalid_transaction(api, client, block_processor):
     api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=1, subscription_expiry=0)
 
     # We need to create the appointment manually
@@ -423,10 +426,9 @@ def test_add_appointment_in_cache_invalid_transaction(api, client):
         "locator": locator,
         "to_self_delay": dummy_appointment_data.get("to_self_delay"),
         "encrypted_blob": encrypted_blob,
-        "user_id": get_random_value_hex(16),
     }
 
-    appointment = ExtendedAppointment.from_dict(appointment_data)
+    appointment = Appointment.from_dict(appointment_data)
     api.watcher.locator_cache.cache[appointment.locator] = dispute_tx.tx_id.hex()
     appointment_signature = Cryptographer.sign(appointment.serialize(), user_sk)
 
@@ -438,11 +440,11 @@ def test_add_appointment_in_cache_invalid_transaction(api, client):
     assert (
         r.status_code == HTTP_OK
         and r.json.get("available_slots") == 0
-        and r.json.get("start_block") == api.watcher.last_known_block
+        and r.json.get("start_block") == block_processor.get_block_count()
     )
 
 
-def test_add_too_many_appointment(api, client):
+def test_add_too_many_appointment(api, client, block_processor):
     # Give slots to the user
     api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=200, subscription_expiry=0)
 
@@ -456,7 +458,7 @@ def test_add_too_many_appointment(api, client):
         r = add_appointment(client, {"appointment": appointment.to_dict(), "signature": appointment_signature}, user_id)
 
         if i < free_appointment_slots:
-            assert r.status_code == HTTP_OK and r.json.get("start_block") == api.watcher.last_known_block
+            assert r.status_code == HTTP_OK and r.json.get("start_block") == block_processor.get_block_count()
         else:
             assert r.status_code == HTTP_SERVICE_UNAVAILABLE
 
@@ -513,9 +515,10 @@ def test_get_appointment_in_watcher(api, client, appointment):
     # Check that the appointment is on the Watcher
     assert r.json.get("status") == "being_watched"
 
+    # Cast the extended appointment (used by the tower) to a regular appointment (used by the user)
+    appointment = Appointment.from_dict(appointment.to_dict())
+
     # Check the the sent appointment matches the received one
-    appointment_dict = appointment.to_dict()
-    appointment_dict.pop("user_id")
     assert r.json.get("locator") == appointment.locator
     assert appointment.to_dict() == r.json.get("appointment")
 

--- a/test/teos/unit/test_extended_appointment.py
+++ b/test/teos/unit/test_extended_appointment.py
@@ -2,24 +2,30 @@ import pytest
 from pytest import fixture
 
 from common.constants import LOCATOR_LEN_BYTES
+from common.cryptographer import Cryptographer
 from teos.extended_appointment import ExtendedAppointment
 
-from test.common.unit.conftest import get_random_value_hex
+from test.teos.unit.conftest import get_random_value_hex, generate_keypair
 
 
 # Parent methods are not tested.
 @fixture
 def appointment_data():
+    sk, pk = generate_keypair()
     locator = get_random_value_hex(LOCATOR_LEN_BYTES)
-    to_self_delay = 20
-    user_id = get_random_value_hex(16)
     encrypted_blob_data = get_random_value_hex(100)
+    to_self_delay = 20
+    user_id = Cryptographer.get_compressed_pk(pk)
+    user_signature = Cryptographer.sign(encrypted_blob_data.encode(), sk)
+    start_block = 300
 
     return {
         "locator": locator,
         "to_self_delay": to_self_delay,
         "encrypted_blob": encrypted_blob_data,
         "user_id": user_id,
+        "user_signature": user_signature,
+        "start_block": start_block,
     }
 
 
@@ -28,9 +34,11 @@ def test_init_appointment(appointment_data):
     # creating appointments.
     appointment = ExtendedAppointment(
         appointment_data["locator"],
-        appointment_data["to_self_delay"],
         appointment_data["encrypted_blob"],
+        appointment_data["to_self_delay"],
         appointment_data["user_id"],
+        appointment_data["user_signature"],
+        appointment_data["start_block"],
     )
 
     assert (
@@ -38,6 +46,8 @@ def test_init_appointment(appointment_data):
         and appointment_data["to_self_delay"] == appointment.to_self_delay
         and appointment_data["encrypted_blob"] == appointment.encrypted_blob
         and appointment_data["user_id"] == appointment.user_id
+        and appointment_data["user_signature"] == appointment.user_signature
+        and appointment_data["start_block"] == appointment.start_block
     )
 
 

--- a/test/teos/unit/test_inspector.py
+++ b/test/teos/unit/test_inspector.py
@@ -2,9 +2,9 @@ import pytest
 from binascii import unhexlify
 
 import common.errors as errors
+from common.appointment import Appointment
 from teos.block_processor import BlockProcessor
 from teos.inspector import Inspector, InspectionFailed
-from teos.extended_appointment import ExtendedAppointment
 
 from common.constants import LOCATOR_LEN_BYTES, LOCATOR_LEN_HEX
 
@@ -175,8 +175,6 @@ def test_check_blob():
 def test_inspect(run_bitcoind):
     # Valid appointment
     locator = get_random_value_hex(LOCATOR_LEN_BYTES)
-    start_time = block_processor.get_block_count() + 5
-    end_time = start_time + 20
     to_self_delay = MIN_TO_SELF_DELAY
     encrypted_blob = get_random_value_hex(64)
 
@@ -185,7 +183,7 @@ def test_inspect(run_bitcoind):
     appointment = inspector.inspect(appointment_data)
 
     assert (
-        type(appointment) == ExtendedAppointment
+        type(appointment) == Appointment
         and appointment.locator == locator
         and appointment.to_self_delay == to_self_delay
         and appointment.encrypted_blob == encrypted_blob

--- a/test/teos/unit/test_inspector.py
+++ b/test/teos/unit/test_inspector.py
@@ -183,8 +183,7 @@ def test_inspect(run_bitcoind):
     appointment = inspector.inspect(appointment_data)
 
     assert (
-        type(appointment) == Appointment
-        and appointment.locator == locator
+        appointment.locator == locator
         and appointment.to_self_delay == to_self_delay
         and appointment.encrypted_blob == encrypted_blob
     )

--- a/watchtower-plugin/watchtower.py
+++ b/watchtower-plugin/watchtower.py
@@ -325,8 +325,8 @@ def on_commitment_revocation(plugin, **kwargs):
         commitment_txid, penalty_tx = arg_parser.parse_add_appointment_arguments(kwargs)
         appointment = Appointment(
             locator=compute_locator(commitment_txid),
-            to_self_delay=20,  # does not matter for now, any value 20-2^32-1 would do
             encrypted_blob=Cryptographer.encrypt(penalty_tx, commitment_txid),
+            to_self_delay=20,  # does not matter for now, any value 20-2^32-1 would do
         )
         signature = Cryptographer.sign(appointment.serialize(), plugin.wt_client.sk)
 


### PR DESCRIPTION
The current serialisation format for appointment signatures differ from the one in BOLT13 (`to_self_delay` and `encrypted_blob` are swapped). Moreover, for appointment accepted messages, the tower does not need to sign the same fields as the user plus the user signature, since signing the latter will implicitly include the former.

This PR modifies both serialisation formats as follows:

Appointment (signed by the user):

`locator | encrypted_blob | to_self_delay`

Receipt (signed by the tower) :

`user_signature | start_block`

Main changes:

`cli`:
- Splits the `add_appointment` method in two: `create_appointment` and `add_appointment`. Also adds stricter checks to the user provided data.

`cli` and `watchtower-plugin`:
- Updates the way the client side computes the data to verify the tower signature (`appointment.serialize` -> `appointment.create_receipt`)

`common`:
- `create_receipt` has been added to `Appointment` as it is used as data to be signed by the tower (instead of `appointment.serialize` as the user does).

`teos`:
- Goes back to using `Appointment` instead of `ExtendedAppointment` in the `api` and `inspector`. The `ExtendedAppointment` is constructed in the `watcher`, since he is the one having all the required data to do so, and also the one that needs to deal with it.
- Adds `start_block` and `user_signature` to the serialization method of `ExtendedAppointment` so that data is also saved on the appointments database.
- Updates the data the tower signs on appointment acceptance (`appointment.serialize` -> `appointment.create_receipt`).

`tests`:

- Updates unit and e2e tests accordingly
- Remove old (unused) tests variables and dictionary fields
- Updates `getblockcount` from `bitcoind_mock` since it had an off-by-one error on computing the height.