### PR TITLE
Sign all (non-get-x) tower responses

### DIFF
--- a/common/appointment.py
+++ b/common/appointment.py
@@ -1,5 +1,4 @@
 import struct
-import pyzbase32
 from binascii import unhexlify
 
 
@@ -73,23 +72,3 @@ class Appointment:
               :obj:`bytes`: The serialized data to be signed.
         """
         return unhexlify(self.locator) + unhexlify(self.encrypted_blob) + struct.pack(">I", self.to_self_delay)
-
-    @staticmethod
-    def create_receipt(user_signature, start_block):
-        """
-        Creates an appointment receipt.
-
-        The receipt has the following format:
-
-            user_signature | start_block
-
-        All values are big endian.
-
-        Args:
-            user_signature (:obj:`str`): the signature of the appointment by the user.
-            start_block (:obj:`str`): the block height at which the tower will start watching for the appointment.
-
-        Returns:
-              :obj:`bytes`: The serialized data to be signed.
-        """
-        return pyzbase32.decode_bytes(user_signature) + struct.pack(">I", start_block)

--- a/common/receipts.py
+++ b/common/receipts.py
@@ -1,4 +1,5 @@
 import struct
+import pyzbase32
 from binascii import unhexlify
 
 from common.tools import is_compressed_pk
@@ -6,15 +7,55 @@ from common.exceptions import InvalidParameter
 
 
 def create_registration_receipt(user_id, available_slots, subscription_expiry):
+    """
+    Creates a registration receipt.
+
+    The receipt has the following format:
+
+        user_id | available_slots | subscription_expiry
+
+    All values are big endian.
+
+    Args:
+        user_id(:obj:`str`): the public key that identifies the user (33-bytes hex str).
+        available_slots (:obj:`int`): the number of slots assigned to a user subscription.
+        subscription_expiry (:obj:`int`): the expiry assigned to a user subscription.
+
+    Returns:
+          :obj:`bytes`: The serialized data to be signed.
+    """
+
     if not is_compressed_pk(user_id):
         raise InvalidParameter("Provided public key does not match expected format (33-byte hex string)")
-    if not isinstance(available_slots, int):
+    elif not isinstance(available_slots, int):
         raise InvalidParameter("Provided available_slots must be an integer")
-    if not isinstance(subscription_expiry, int):
+    elif not isinstance(subscription_expiry, int):
         raise InvalidParameter("Provided subscription_expiry must be an integer")
 
     return unhexlify(user_id) + struct.pack(">I", available_slots) + struct.pack(">I", subscription_expiry)
 
 
-def create_appointment_receipt():
-    pass
+def create_appointment_receipt(user_signature, start_block):
+    """
+    Creates an appointment receipt.
+
+    The receipt has the following format:
+
+        user_signature | start_block
+
+    All values are big endian.
+
+    Args:
+        user_signature (:obj:`str`): the signature of the appointment by the user.
+        start_block (:obj:`int`): the block height at which the tower will start watching for the appointment.
+
+    Returns:
+          :obj:`bytes`: The serialized data to be signed.
+    """
+
+    if not isinstance(user_signature, str):
+        raise InvalidParameter("Provided user_signature is invalid")
+    elif not isinstance(start_block, int):
+        raise InvalidParameter("Provided start_block is invalid")
+
+    return pyzbase32.decode_bytes(user_signature) + struct.pack(">I", start_block)

--- a/common/receipts.py
+++ b/common/receipts.py
@@ -1,0 +1,20 @@
+import struct
+from binascii import unhexlify
+
+from common.tools import is_compressed_pk
+from common.exceptions import InvalidParameter
+
+
+def create_registration_receipt(user_id, available_slots, subscription_expiry):
+    if not is_compressed_pk(user_id):
+        raise InvalidParameter("Provided public key does not match expected format (33-byte hex string)")
+    if not isinstance(available_slots, int):
+        raise InvalidParameter("Provided available_slots must be an integer")
+    if not isinstance(subscription_expiry, int):
+        raise InvalidParameter("Provided subscription_expiry must be an integer")
+
+    return unhexlify(user_id) + struct.pack(">I", available_slots) + struct.pack(">I", subscription_expiry)
+
+
+def create_appointment_receipt():
+    pass

--- a/common/tools.py
+++ b/common/tools.py
@@ -31,6 +31,19 @@ def is_256b_hex_str(value):
     return isinstance(value, str) and re.match(r"^[0-9A-Fa-f]{64}$", value) is not None
 
 
+def is_u4int(value):
+    """
+    Checks if a given value is an unsigned 4-byte integer.
+
+    Args:
+        value(:mod:`int`): the value to be checked.
+
+    Returns:
+        :obj:`bool`: Whether or not the value matches the format.
+    """
+    return isinstance(value, int) and 0 <= value <= pow(2, 32) - 1
+
+
 def is_locator(value):
     """
     Checks if a given value is a 16-byte hex encoded string.

--- a/teos/api.py
+++ b/teos/api.py
@@ -126,11 +126,12 @@ class API:
         if user_id:
             try:
                 rcode = HTTP_OK
-                available_slots, subscription_expiry = self.watcher.gatekeeper.add_update_user(user_id)
+                available_slots, subscription_expiry, subscription_signature = self.watcher.register(user_id)
                 response = {
                     "public_key": user_id,
                     "available_slots": available_slots,
                     "subscription_expiry": subscription_expiry,
+                    "subscription_signature": subscription_signature,
                 }
 
             except InvalidParameter as e:

--- a/teos/gatekeeper.py
+++ b/teos/gatekeeper.py
@@ -1,7 +1,7 @@
 from math import ceil
 from threading import Lock
 
-from common.tools import is_compressed_pk
+from common.tools import is_compressed_pk, is_u4int
 from common.cryptographer import Cryptographer
 from common.receipts import create_registration_receipt
 from common.constants import ENCRYPTED_BLOB_MAX_SIZE_HEX
@@ -101,6 +101,9 @@ class Gatekeeper:
             )
         else:
             # FIXME: For now new calls to register add subscription_slots to the current count and reset the expiry time
+            if not is_u4int(self.registered_users[user_id].available_slots + self.subscription_slots):
+                raise InvalidParameter("Maximum slots reached for the subscription")
+
             self.registered_users[user_id].available_slots += self.subscription_slots
             self.registered_users[user_id].subscription_expiry = (
                 self.block_processor.get_block_count() + self.subscription_duration

--- a/teos/gatekeeper.py
+++ b/teos/gatekeeper.py
@@ -3,6 +3,7 @@ from threading import Lock
 
 from common.tools import is_compressed_pk
 from common.cryptographer import Cryptographer
+from common.receipts import create_registration_receipt
 from common.constants import ENCRYPTED_BLOB_MAX_SIZE_HEX
 from common.exceptions import InvalidParameter, InvalidKey, SignatureError
 
@@ -84,8 +85,8 @@ class Gatekeeper:
             user_id(:obj:`str`): the public key that identifies the user (33-bytes hex str).
 
         Returns:
-            :obj:`tuple`: a tuple with the number of available slots in the user subscription and the subscription
-            expiry (in absolute block height).
+            :obj:`tuple`: a tuple with the number of available slots in the user subscription, the subscription
+            expiry (in absolute block height), and the registration_receipt.
 
         Raises:
             :obj:`InvalidParameter`: if the user_pk does not match the expected format.
@@ -106,8 +107,15 @@ class Gatekeeper:
             )
 
         self.user_db.store_user(user_id, self.registered_users[user_id].to_dict())
+        receipt = create_registration_receipt(
+            user_id, self.registered_users[user_id].available_slots, self.registered_users[user_id].subscription_expiry
+        )
 
-        return self.registered_users[user_id].available_slots, self.registered_users[user_id].subscription_expiry
+        return (
+            self.registered_users[user_id].available_slots,
+            self.registered_users[user_id].subscription_expiry,
+            receipt,
+        )
 
     def authenticate_user(self, message, signature):
         """

--- a/teos/watcher.py
+++ b/teos/watcher.py
@@ -227,6 +227,23 @@ class Watcher:
 
         return watcher_thread
 
+    def register(self, user_id):
+        """
+        Registers a user.
+
+        Args:
+            user_id(:obj:`str`): the public key that identifies the user (33-bytes hex str).
+
+        Returns:
+            :obj:`tuple`: A tuple containing the available slots, the subscription expiry, and the signature of the
+            registration receipt by the Watcher.
+        """
+
+        available_slots, subscription_expiry, registration_receipt = self.gatekeeper.add_update_user(user_id)
+        signature = Cryptographer.sign(registration_receipt, self.signing_key)
+
+        return available_slots, subscription_expiry, signature
+
     def add_appointment(self, appointment, user_signature):
         """
         Adds a new appointment to the ``appointments`` dictionary if ``max_appointments`` has not been reached.

--- a/teos/watcher.py
+++ b/teos/watcher.py
@@ -262,6 +262,9 @@ class Watcher:
         Returns:
             :obj:`tuple`: A tuple containing the appointment data and the status (either "being_watched" or
             "dispute_responded").
+
+        Raises:
+            :obj:`AppointmentNotFound`: If the appointment is not found in the tower.
         """
 
         message = "get appointment {}".format(locator).encode()

--- a/teos/watcher.py
+++ b/teos/watcher.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from readerwriterlock import rwlock
 
 from common.logger import Logger
+import common.receipts as receipts
 from common.tools import compute_locator
 from common.exceptions import BasicException
 from common.exceptions import EncryptionError
@@ -349,7 +350,7 @@ class Watcher:
 
         try:
             signature = Cryptographer.sign(
-                ExtendedAppointment.create_receipt(user_signature, start_block), self.signing_key
+                receipts.create_appointment_receipt(user_signature, start_block), self.signing_key
             )
 
         except (InvalidParameter, SignatureError):

--- a/test/cli/unit/test_teos_cli.py
+++ b/test/cli/unit/test_teos_cli.py
@@ -120,19 +120,19 @@ def test_register_no_signature():
 def test_register_with_invalid_user_id():
     # Simulate a register response
     with pytest.raises(InvalidParameter):
-        teos_cli.register("invalid_user_id", teos_url)
+        teos_cli.register("invalid_user_id", dummy_teos_id, teos_url)
 
 
 def test_register_with_connection_error():
     # We don't mock any url to simulate a connection error
     with pytest.raises(ConnectionError):
-        teos_cli.register(dummy_user_id, teos_url)
+        teos_cli.register(dummy_user_id, dummy_teos_id, teos_url)
 
     # Should also fail with missing or unknown protocol, with a more specific error message
     with pytest.raises(ConnectionError, match="Invalid URL"):
-        teos_cli.register(dummy_user_id, "//teos.watch")
+        teos_cli.register(dummy_user_id, dummy_teos_id, "//teos.watch")
     with pytest.raises(ConnectionError, match="Invalid URL"):
-        teos_cli.register(dummy_user_id, "nonExistingProtocol://teos.watch")
+        teos_cli.register(dummy_user_id, dummy_teos_id, "nonExistingProtocol://teos.watch")
 
 
 def test_create_appointment():
@@ -269,9 +269,7 @@ def test_get_appointment_tower_error():
     # Test that a TowerResponseError is raised if the response is invalid.
     locator = dummy_appointment_dict.get("locator")
 
-    responses.add(
-        responses.POST, get_appointment_endpoint, body="{ invalid json response", status=200,
-    )
+    responses.add(responses.POST, get_appointment_endpoint, body="{ invalid json response", status=200)
     with pytest.raises(TowerResponseError):
         teos_cli.get_appointment(locator, dummy_user_sk, dummy_teos_id, teos_url)
 
@@ -424,10 +422,7 @@ def test_save_appointment_receipt(monkeypatch):
 def test_get_all_appointments():
     # Response of get_all_appointments endpoint is all appointments from watcher and responder.
     dummy_appointment_dict["status"] = "being_watched"
-    response = {
-        "watcher_appointments": dummy_appointment_dict,
-        "responder_trackers": {},
-    }
+    response = {"watcher_appointments": dummy_appointment_dict, "responder_trackers": {}}
 
     request_url = get_all_appointments_endpoint
     responses.add(responses.GET, request_url, json=response, status=200)

--- a/test/common/unit/conftest.py
+++ b/test/common/unit/conftest.py
@@ -3,6 +3,7 @@ import random
 from shutil import rmtree
 
 from common.db_manager import DBManager
+from common.constants import LOCATOR_LEN_BYTES
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -19,6 +20,23 @@ def db_manager():
 
     manager.db.close()
     rmtree("test_db")
+
+
+@pytest.fixture
+def appointment_data():
+    locator = get_random_value_hex(LOCATOR_LEN_BYTES)
+    start_time = 100
+    end_time = 120
+    to_self_delay = 20
+    encrypted_blob_data = get_random_value_hex(100)
+
+    return {
+        "locator": locator,
+        "start_time": start_time,
+        "end_time": end_time,
+        "to_self_delay": to_self_delay,
+        "encrypted_blob": encrypted_blob_data,
+    }
 
 
 def get_random_value_hex(nbytes):

--- a/test/common/unit/test_appointment.py
+++ b/test/common/unit/test_appointment.py
@@ -91,16 +91,3 @@ def test_serialize(appointment_data):
     assert binascii.hexlify(locator).decode() == appointment.locator
     assert binascii.hexlify(encrypted_blob).decode() == appointment.encrypted_blob
     assert struct.unpack(">I", to_self_delay)[0] == appointment.to_self_delay
-
-
-def test_create_receipt(appointment_data):
-    # Not much to test here, basically making sure the fields are in the correct order
-    # The receipt format is user_signature | start_block
-    sk = PrivateKey.from_int(42)
-    data = get_random_value_hex(120)
-    signature = Cryptographer.sign(data.encode(), sk)
-    start_block = 200
-    receipt = Appointment.create_receipt(signature, start_block)
-
-    assert pyzbase32.encode_bytes(receipt[:-4]).decode() == signature
-    assert struct.unpack(">I", receipt[-4:])[0] == start_block

--- a/test/common/unit/test_appointment.py
+++ b/test/common/unit/test_appointment.py
@@ -1,33 +1,8 @@
 import struct
 import pytest
 import binascii
-import pyzbase32
-from pytest import fixture
-from coincurve import PrivateKey
 
 from common.appointment import Appointment
-from common.cryptographer import Cryptographer
-from common.constants import LOCATOR_LEN_BYTES
-
-from test.common.unit.conftest import get_random_value_hex
-
-
-# Not much to test here, adding it for completeness
-@fixture
-def appointment_data():
-    locator = get_random_value_hex(LOCATOR_LEN_BYTES)
-    start_time = 100
-    end_time = 120
-    to_self_delay = 20
-    encrypted_blob_data = get_random_value_hex(100)
-
-    return {
-        "locator": locator,
-        "start_time": start_time,
-        "end_time": end_time,
-        "to_self_delay": to_self_delay,
-        "encrypted_blob": encrypted_blob_data,
-    }
 
 
 def test_init_appointment(appointment_data):

--- a/test/common/unit/test_receipts.py
+++ b/test/common/unit/test_receipts.py
@@ -1,0 +1,74 @@
+import struct
+import pytest
+import pyzbase32
+from binascii import hexlify
+from coincurve import PrivateKey
+
+from common import receipts as receipts
+from common.cryptographer import Cryptographer
+from common.exceptions import InvalidParameter
+
+from test.common.unit.conftest import get_random_value_hex
+
+
+def test_create_registration_receipt():
+    # Not much to test here, basically making sure the fields are in the correct order
+    # The receipt format is user_id | available_slots | subscription_expiry
+
+    user_id = "02" + get_random_value_hex(32)
+    available_slots = 100
+    subscription_expiry = 4320
+
+    registration_receipt = receipts.create_registration_receipt(user_id, available_slots, subscription_expiry)
+
+    assert hexlify(registration_receipt[:33]).decode() == user_id
+    assert struct.unpack(">I", registration_receipt[33:37])[0] == available_slots
+    assert struct.unpack(">I", registration_receipt[37:])[0] == subscription_expiry
+
+
+def test_create_registration_receipt_wrong_inputs():
+    user_id = "02" + get_random_value_hex(32)
+    available_slots = 100
+    subscription_expiry = 4320
+
+    wrong_user_ids = ["01" + get_random_value_hex(32), "04" + get_random_value_hex(31), "06" + get_random_value_hex(33)]
+    no_int = [{}, object, "", [], 3.4, None]
+
+    for wrong_param in wrong_user_ids + no_int:
+        with pytest.raises(InvalidParameter, match="public key does not match expected format"):
+            receipts.create_registration_receipt(wrong_param, available_slots, subscription_expiry)
+        with pytest.raises(InvalidParameter, match="available_slots must be an integer"):
+            receipts.create_registration_receipt(user_id, wrong_param, subscription_expiry)
+        with pytest.raises(InvalidParameter, match="subscription_expiry must be an integer"):
+            receipts.create_registration_receipt(user_id, available_slots, wrong_param)
+
+
+def test_create_appointment_receipt(appointment_data):
+    # Not much to test here, basically making sure the fields are in the correct order
+    # The receipt format is user_signature | start_block
+    sk = PrivateKey.from_int(42)
+    data = get_random_value_hex(120)
+    signature = Cryptographer.sign(data.encode(), sk)
+    start_block = 200
+
+    receipt = receipts.create_appointment_receipt(signature, start_block)
+
+    assert pyzbase32.encode_bytes(receipt[:-4]).decode() == signature
+    assert struct.unpack(">I", receipt[-4:])[0] == start_block
+
+
+def test_create_appointment_receipt_wrong_inputs():
+    sk = PrivateKey.from_int(42)
+    data = get_random_value_hex(120)
+    signature = Cryptographer.sign(data.encode(), sk)
+    start_block = 200
+
+    no_str = [{}, [], None, 15, 4.5, dict(), object, True]
+    no_int = [{}, [], None, "", 4.5, dict(), object]
+
+    for wrong_param in no_str:
+        with pytest.raises(InvalidParameter, match="Provided user_signature is invalid"):
+            receipts.create_appointment_receipt(wrong_param, start_block)
+    for wrong_param in no_int:
+        with pytest.raises(InvalidParameter, match="Provided start_block is invalid"):
+            receipts.create_appointment_receipt(signature, wrong_param)

--- a/test/common/unit/test_receipts.py
+++ b/test/common/unit/test_receipts.py
@@ -33,14 +33,21 @@ def test_create_registration_receipt_wrong_inputs():
 
     wrong_user_ids = ["01" + get_random_value_hex(32), "04" + get_random_value_hex(31), "06" + get_random_value_hex(33)]
     no_int = [{}, object, "", [], 3.4, None]
+    overflow_iu4nt = pow(2, 32)
 
     for wrong_param in wrong_user_ids + no_int:
         with pytest.raises(InvalidParameter, match="public key does not match expected format"):
             receipts.create_registration_receipt(wrong_param, available_slots, subscription_expiry)
-        with pytest.raises(InvalidParameter, match="available_slots must be an integer"):
+        with pytest.raises(InvalidParameter, match="available_slots must be a 4-byte unsigned integer"):
             receipts.create_registration_receipt(user_id, wrong_param, subscription_expiry)
-        with pytest.raises(InvalidParameter, match="subscription_expiry must be an integer"):
+        with pytest.raises(InvalidParameter, match="subscription_expiry must be a 4-byte unsigned integer"):
             receipts.create_registration_receipt(user_id, available_slots, wrong_param)
+
+    # Same for overflow u4int
+    with pytest.raises(InvalidParameter, match="available_slots must be a 4-byte unsigned integer"):
+        receipts.create_registration_receipt(user_id, overflow_iu4nt, subscription_expiry)
+    with pytest.raises(InvalidParameter, match="subscription_expiry must be a 4-byte unsigned integer"):
+        receipts.create_registration_receipt(user_id, available_slots, overflow_iu4nt)
 
 
 def test_create_appointment_receipt(appointment_data):
@@ -62,13 +69,18 @@ def test_create_appointment_receipt_wrong_inputs():
     data = get_random_value_hex(120)
     signature = Cryptographer.sign(data.encode(), sk)
     start_block = 200
+    overflow_iu4nt = pow(2, 32)
 
     no_str = [{}, [], None, 15, 4.5, dict(), object, True]
     no_int = [{}, [], None, "", 4.5, dict(), object]
 
     for wrong_param in no_str:
-        with pytest.raises(InvalidParameter, match="Provided user_signature is invalid"):
+        with pytest.raises(InvalidParameter, match="user_signature is invalid"):
             receipts.create_appointment_receipt(wrong_param, start_block)
     for wrong_param in no_int:
-        with pytest.raises(InvalidParameter, match="Provided start_block is invalid"):
+        with pytest.raises(InvalidParameter, match="must be a 4-byte unsigned integer"):
             receipts.create_appointment_receipt(signature, wrong_param)
+
+    # Same for overflow u4int
+    with pytest.raises(InvalidParameter, match="start_block must be a 4-byte unsigned integer"):
+        receipts.create_appointment_receipt(signature, overflow_iu4nt)

--- a/test/common/unit/test_tools.py
+++ b/test/common/unit/test_tools.py
@@ -9,6 +9,7 @@ from common.tools import (
     compute_locator,
     setup_data_folder,
     setup_logging,
+    is_u4int,
 )
 from test.common.unit.conftest import get_random_value_hex
 
@@ -49,6 +50,24 @@ def test_is_256b_hex_str():
 
     for v in range(100):
         assert is_256b_hex_str(get_random_value_hex(32)) is True
+
+
+def test_is_u4int():
+    out_of_range = [-1, pow(2, 32)]
+    in_range = [0, pow(2, 32) // 2, pow(2, 32) - 1]
+    wrong_inputs = [None, str(), 46.67, dict(), "A", bytes(), get_random_value_hex(31)]
+
+    # Test ints out of the range return false
+    for x in out_of_range:
+        assert not is_u4int(x)
+
+    # Same for wrong inputs
+    for x in wrong_inputs:
+        assert not is_u4int(x)
+
+    # True is returned for values in range
+    for x in in_range:
+        assert is_u4int(x)
 
 
 def test_check_locator_format():

--- a/test/teos/e2e/test_basic_e2e.py
+++ b/test/teos/e2e/test_basic_e2e.py
@@ -8,6 +8,7 @@ from coincurve import PrivateKey
 from cli.exceptions import TowerResponseError
 from cli import teos_cli, DATA_DIR, DEFAULT_CONF, CONF_FILE_NAME
 
+import common.receipts as receipts
 from common.tools import compute_locator
 from common.appointment import Appointment
 from common.cryptographer import Cryptographer
@@ -85,7 +86,7 @@ def test_commands_registered(bitcoin_cli):
     global appointments_in_watcher
 
     # Test registering and trying again
-    teos_cli.register(user_id, teos_base_endpoint)
+    teos_cli.register(user_id, teos_id, teos_base_endpoint)
 
     # Add appointment
     commitment_tx, penalty_tx = create_txs(bitcoin_cli)
@@ -106,8 +107,7 @@ def test_appointment_life_cycle(bitcoin_cli):
     global appointments_in_watcher, appointments_in_responder
 
     # First of all we need to register
-    response = teos_cli.register(user_id, teos_base_endpoint)
-    available_slots = response.get("available_slots")
+    available_slots, subscription_expiry = teos_cli.register(user_id, teos_id, teos_base_endpoint)
 
     # After that we can build an appointment and send it to the tower
     commitment_tx, penalty_tx = create_txs(bitcoin_cli)
@@ -165,9 +165,9 @@ def test_appointment_life_cycle(bitcoin_cli):
 
     # Check that the appointment is not in the Gatekeeper by checking the available slots (should have increase by 1)
     # We can do so by topping up the subscription (FIXME: find a better way to check this).
-    response = teos_cli.register(user_id, teos_base_endpoint)
+    available_slots_response, _ = teos_cli.register(user_id, teos_id, teos_base_endpoint)
     assert (
-        response.get("available_slots")
+        available_slots_response
         == available_slots
         + teos_config.get("SUBSCRIPTION_SLOTS")
         + 1
@@ -288,7 +288,7 @@ def test_appointment_wrong_decryption_key(bitcoin_cli):
 
     # Check that the server has accepted the appointment
     tower_signature = response_json.get("signature")
-    appointment_receipt = Appointment.create_receipt(signature, response_json.get("start_block"))
+    appointment_receipt = receipts.create_appointment_receipt(signature, response_json.get("start_block"))
     rpk = Cryptographer.recover_pk(appointment_receipt, tower_signature)
     assert teos_id == Cryptographer.get_compressed_pk(rpk)
     assert response_json.get("locator") == appointment.locator
@@ -393,7 +393,7 @@ def test_two_appointment_same_locator_different_penalty_different_users(bitcoin_
     # tmp keys for a different user
     tmp_user_sk = PrivateKey()
     tmp_user_id = hexlify(tmp_user_sk.public_key.format(compressed=True)).decode("utf-8")
-    teos_cli.register(tmp_user_id, teos_base_endpoint)
+    teos_cli.register(user_id, teos_id, teos_base_endpoint)
 
     appointment_1 = teos_cli.create_appointment(appointment1_data)
     add_appointment(appointment_1)
@@ -480,7 +480,7 @@ def test_add_appointment_trigger_on_cache_cannot_decrypt(bitcoin_cli):
 
     # Check that the server has accepted the appointment
     tower_signature = response_json.get("signature")
-    appointment_receipt = Appointment.create_receipt(signature, response_json.get("start_block"))
+    appointment_receipt = receipts.create_appointment_receipt(signature, response_json.get("start_block"))
     rpk = Cryptographer.recover_pk(appointment_receipt, tower_signature)
     assert teos_id == Cryptographer.get_compressed_pk(rpk)
     assert response_json.get("locator") == appointment.locator

--- a/test/teos/e2e/test_basic_e2e.py
+++ b/test/teos/e2e/test_basic_e2e.py
@@ -393,7 +393,7 @@ def test_two_appointment_same_locator_different_penalty_different_users(bitcoin_
     # tmp keys for a different user
     tmp_user_sk = PrivateKey()
     tmp_user_id = hexlify(tmp_user_sk.public_key.format(compressed=True)).decode("utf-8")
-    teos_cli.register(user_id, teos_id, teos_base_endpoint)
+    teos_cli.register(tmp_user_id, teos_id, teos_base_endpoint)
 
     appointment_1 = teos_cli.create_appointment(appointment1_data)
     add_appointment(appointment_1)

--- a/test/teos/unit/test_inspector.py
+++ b/test/teos/unit/test_inspector.py
@@ -2,7 +2,6 @@ import pytest
 from binascii import unhexlify
 
 import common.errors as errors
-from common.appointment import Appointment
 from teos.block_processor import BlockProcessor
 from teos.inspector import Inspector, InspectionFailed
 

--- a/test/teos/unit/test_watcher.py
+++ b/test/teos/unit/test_watcher.py
@@ -22,6 +22,7 @@ from teos.watcher import (
     AppointmentAlreadyTriggered,
 )
 
+import common.receipts as receipts
 from common.tools import compute_locator
 from common.appointment import Appointment
 from common.cryptographer import Cryptographer
@@ -354,7 +355,8 @@ def test_add_appointment(watcher):
     assert response.get("locator") == appointment.locator
     assert Cryptographer.get_compressed_pk(watcher.signing_key.public_key) == Cryptographer.get_compressed_pk(
         Cryptographer.recover_pk(
-            Appointment.create_receipt(appointment_signature, response.get("start_block")), response.get("signature")
+            receipts.create_appointment_receipt(appointment_signature, response.get("start_block")),
+            response.get("signature"),
         )
     )
     assert response.get("available_slots") == available_slots - 1
@@ -364,7 +366,8 @@ def test_add_appointment(watcher):
     assert response.get("locator") == appointment.locator
     assert Cryptographer.get_compressed_pk(watcher.signing_key.public_key) == Cryptographer.get_compressed_pk(
         Cryptographer.recover_pk(
-            Appointment.create_receipt(appointment_signature, response.get("start_block")), response.get("signature")
+            receipts.create_appointment_receipt(appointment_signature, response.get("start_block")),
+            response.get("signature"),
         )
     )
     # The slot count should not have been reduced and only one copy is kept.
@@ -383,7 +386,8 @@ def test_add_appointment(watcher):
     assert response.get("locator") == appointment.locator
     assert Cryptographer.get_compressed_pk(watcher.signing_key.public_key) == Cryptographer.get_compressed_pk(
         Cryptographer.recover_pk(
-            Appointment.create_receipt(appointment_signature, response.get("start_block")), response.get("signature")
+            receipts.create_appointment_receipt(appointment_signature, response.get("start_block")),
+            response.get("signature"),
         )
     )
     assert response.get("available_slots") == available_slots - 1
@@ -403,7 +407,7 @@ def test_add_appointment_in_cache(watcher):
     # Try to add the appointment
     user_signature = Cryptographer.sign(appointment.serialize(), user_sk)
     response = watcher.add_appointment(appointment, user_signature)
-    appointment_receipt = Appointment.create_receipt(user_signature, response.get("start_block"))
+    appointment_receipt = receipts.create_appointment_receipt(user_signature, response.get("start_block"))
 
     # The appointment is accepted but it's not in the Watcher
     assert (
@@ -450,7 +454,7 @@ def test_add_appointment_in_cache_invalid_blob(watcher):
     # Try to add the appointment
     user_signature = Cryptographer.sign(appointment.serialize(), user_sk)
     response = watcher.add_appointment(appointment, user_signature)
-    appointment_receipt = Appointment.create_receipt(user_signature, response.get("start_block"))
+    appointment_receipt = receipts.create_appointment_receipt(user_signature, response.get("start_block"))
 
     # The appointment is accepted but dropped (same as an invalid appointment that gets triggered)
     assert (
@@ -478,7 +482,7 @@ def test_add_appointment_in_cache_invalid_transaction(watcher):
     # Try to add the appointment
     user_signature = Cryptographer.sign(appointment.serialize(), user_sk)
     response = watcher.add_appointment(appointment, user_signature)
-    appointment_receipt = Appointment.create_receipt(user_signature, response.get("start_block"))
+    appointment_receipt = receipts.create_appointment_receipt(user_signature, response.get("start_block"))
 
     # The appointment is accepted but dropped (same as an invalid appointment that gets triggered)
     assert (
@@ -506,7 +510,7 @@ def test_add_too_many_appointments(watcher):
         appointment, dispute_tx = generate_dummy_appointment()
         appointment_signature = Cryptographer.sign(appointment.serialize(), user_sk)
         response = watcher.add_appointment(appointment, appointment_signature)
-        appointment_receipt = Appointment.create_receipt(appointment_signature, response.get("start_block"))
+        appointment_receipt = receipts.create_appointment_receipt(appointment_signature, response.get("start_block"))
 
         assert response.get("locator") == appointment.locator
         assert Cryptographer.get_compressed_pk(watcher.signing_key.public_key) == Cryptographer.get_compressed_pk(

--- a/watchtower-plugin/retrier.py
+++ b/watchtower-plugin/retrier.py
@@ -125,6 +125,7 @@ class Retrier:
                     "appointment": appointment_dict,
                     "signature": e.kwargs.get("signature"),
                     "recovered_id": e.kwargs.get("recovered_id"),
+                    "receipt": e.kwargs.get("receipt"),
                 }
 
             except TowerConnectionError:

--- a/watchtower-plugin/tower_info.py
+++ b/watchtower-plugin/tower_info.py
@@ -41,7 +41,7 @@ class TowerInfo:
 
         Returns:
             :obj:`TowerInfo`: A TowerInfo object built with the provided data.
-            
+
         Raises:
             :obj:`ValueError`: If any of the expected fields is missing in the dictionary.
         """

--- a/watchtower-plugin/towers_dbm.py
+++ b/watchtower-plugin/towers_dbm.py
@@ -45,7 +45,8 @@ class TowersDBM(DBManager):
 
             except (json.JSONDecodeError, TypeError):
                 self.plugin.log(
-                    f"Could't add tower to db. Wrong tower data format (tower_id={tower_id}, tower_data={tower_data.to_dict()})"
+                    f"Could't add tower to db. Wrong tower data format (tower_id={tower_id}, "
+                    f"tower_data={tower_data.to_dict()})"
                 )
                 return False
 

--- a/watchtower-plugin/watchtower.py
+++ b/watchtower-plugin/watchtower.py
@@ -313,7 +313,8 @@ def retry_tower(plugin, tower_id):
     #        subscription error.
     if tower.status not in ["unreachable", "subscription error"]:
         response = {
-            "error": f"Cannot retry tower. Expected tower status 'unreachable' or 'subscription error'. Received {tower.status}"
+            "error": f"Cannot retry tower. Expected tower status 'unreachable' or 'subscription error'. "
+            f"Received {tower.status}"
         }
     if not tower.pending_appointments:
         response = {"error": f"{tower_id} does not have pending appointments"}


### PR DESCRIPTION
Adds a tower signature to the missing tower responses that are not a `get_x` request. 

`get_x` responses are not signed since they do not imply any agreement between the user and the tower, so making sure the communication happens trough an authenticated channel should suffice. With respect to other requests (register, add_appointment, ...) they represent an agreement between the two parties. Therefore, misbehaving should be provable.

This PR removes the `create_receipt` method from `Appointment`, and creates a file in `common` called `receipts`. Given that multiple receipts may be needed (currently there are two: registration and add_appointment) and that the user and tower need to know exactly how to construct them, it seems better to have a single place for them.

Furthermore, since the responses are signed by the `Watcher`, a register method has been created to handle the creation instead of bypassing it to the `Gatekeeper` (it didn't feel right that the API was calling the gatekeeper bypassing the `Watcher` either).

Finally, `get_appoinment` functionality has also being swift from the API to the `Watcher`. This was done first in order to allow the `Watcher` to sign the response, but after deciding not to sign `get_x` responses it has been kept to simplify the API. Turns out it is way simpler to be handled by the `Watcher`.

The c-lightning Watchtower plugin has been updated accordingly. This will require to release a new version of `common` on PyPi to ensure it works (can be done alongside the next release).