### PR TITLE
Adds a "daemon" flag

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests
 plyvel
 readerwriterlock
 structlog
+python-daemon

--- a/teos/__init__.py
+++ b/teos/__init__.py
@@ -16,6 +16,7 @@ DEFAULT_CONF = {
     "BTC_FEED_PROTOCOL": {"value": "tcp", "type": str},
     "BTC_FEED_CONNECT": {"value": "localhost", "type": str},
     "BTC_FEED_PORT": {"value": 28332, "type": int},
+    "DAEMON": {"value": False, "type": bool},
     "MAX_APPOINTMENTS": {"value": 1000000, "type": int},
     "SUBSCRIPTION_SLOTS": {"value": 100, "type": int},
     "SUBSCRIPTION_DURATION": {"value": 4320, "type": int},

--- a/teos/help.py
+++ b/teos/help.py
@@ -14,6 +14,7 @@ def show_usage():
         "\n\t--btcfeedconnect \tbitcoind zmq hostname (for blocks). Defaults to 'localhost'."
         "\n\t--btcfeedport \t\tbitcoind zmq port (for blocks). Defaults to '28332'."
         "\n\t--datadir \t\tspecify data directory. Defaults to '~\.teos'."
+        "\n\t--daemon \t\trun in background as a daemon."
         "\n\t--overwritekey \t\toverwrites the tower secret key. THIS IS IRREVERSIBLE AND WILL CHANGE YOUR TOWER ID."
         "\n\t-h --help \t\tshows this message."
     )

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -3,6 +3,8 @@ from sys import argv, exit
 from getopt import getopt, GetoptError
 from signal import signal, SIGINT, SIGQUIT, SIGTERM
 
+import daemon
+
 from common.logger import setup_logging, get_logger
 from common.config_loader import ConfigLoader
 from common.cryptographer import Cryptographer
@@ -215,6 +217,7 @@ if __name__ == "__main__":
                 "btcfeedconnect=",
                 "btcfeedport=",
                 "datadir=",
+                "daemon",
                 "overwritekey",
                 "help",
             ],
@@ -249,6 +252,8 @@ if __name__ == "__main__":
                     exit("btcfeedport must be an integer")
             if opt in ["--datadir"]:
                 command_line_conf["DATA_DIR"] = os.path.expanduser(arg)
+            if opt in ["--daemon"]:
+                command_line_conf["DAEMON"] = True
             if opt in ["--overwritekey"]:
                 command_line_conf["OVERWRITE_KEY"] = True
             if opt in ["-h", "--help"]:
@@ -258,5 +263,9 @@ if __name__ == "__main__":
         exit(e)
 
     config = get_config(command_line_conf)
-
-    main(config)
+    if config.get("DAEMON"):
+        print("Starting TEOS in daemon mode.")
+        with daemon.DaemonContext():
+            main(config)
+    else:
+        main(config)

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -207,7 +207,7 @@ if __name__ == "__main__":
     try:
         opts, _ = getopt(
             argv[1:],
-            "h",
+            "hd",
             [
                 "apibind=",
                 "apiport=",
@@ -254,7 +254,7 @@ if __name__ == "__main__":
                     exit("btcfeedport must be an integer")
             if opt in ["--datadir"]:
                 command_line_conf["DATA_DIR"] = os.path.expanduser(arg)
-            if opt in ["--daemon"]:
+            if opt in ["-d", "--daemon"]:
                 command_line_conf["DAEMON"] = True
             if opt in ["--overwritekey"]:
                 command_line_conf["OVERWRITE_KEY"] = True

--- a/test/teos/e2e/conftest.py
+++ b/test/teos/e2e/conftest.py
@@ -82,7 +82,7 @@ def create_txs(bitcoin_cli, n=1):
         return signed_commitment_txs[0], signed_penalty_txs[0]
 
 
-def run_teosd(datadir):
+def run_teosd(config, datadir):
     sk_file_path = os.path.join(datadir, "teos_sk.der")
     if not os.path.exists(sk_file_path):
         # Generating teos sk so we can return the teos_id
@@ -93,7 +93,7 @@ def run_teosd(datadir):
 
     teos_id = Cryptographer.get_compressed_pk(teos_sk.public_key)
 
-    teosd_process = Process(target=main, kwargs={"command_line_conf": {}}, daemon=True)
+    teosd_process = Process(target=main, kwargs={"config": config}, daemon=True)
     teosd_process.start()
 
     return teosd_process, teos_id

--- a/test/teos/e2e/conftest.py
+++ b/test/teos/e2e/conftest.py
@@ -39,7 +39,7 @@ def prng_seed():
 @pytest.fixture(scope="session", autouse=True)
 def setup_node(bitcoin_cli):
 
-    # Check that the nodes is up and running (specially for circleci)
+    # Check that the node is up and running (especially for circleci)
     while True:
         try:
             new_addr = bitcoin_cli.getnewaddress()
@@ -48,7 +48,7 @@ def setup_node(bitcoin_cli):
             if "Loading wallet..." in str(e):
                 sleep(1)
 
-    # This method will create a new address a mine bitcoin so the node can be used for testing
+    # This method will create a new address and mine bitcoin so the node can be used for testing
     bitcoin_cli.generatetoaddress(200, new_addr)
 
 
@@ -106,7 +106,7 @@ def get_random_value_hex(nbytes):
 
 
 def create_commitment_tx(bitcoin_cli, utxo, destination=None):
-    # We will set the recipient to ourselves is destination is None
+    # We will set the recipient to ourselves if destination is None
     if destination is None:
         destination = utxo.get("address")
 
@@ -123,7 +123,7 @@ def create_commitment_tx(bitcoin_cli, utxo, destination=None):
 
 
 def create_penalty_tx(bitcoin_cli, decoded_commitment_tx, destination=None):
-    # We will set the recipient to ourselves is destination is None
+    # We will set the recipient to ourselves if destination is None
     if destination is None:
         destination = decoded_commitment_tx.get("vout")[0].get("scriptPubKey").get("addresses")[0]
 

--- a/test/teos/e2e/test_basic_e2e.py
+++ b/test/teos/e2e/test_basic_e2e.py
@@ -39,7 +39,7 @@ teos_get_appointment_endpoint = "{}/get_appointment".format(teos_base_endpoint)
 teos_get_all_appointments_endpoint = "{}/get_all_appointments".format(teos_base_endpoint)
 
 # Run teosd
-teosd_process, teos_id = run_teosd(teos_datadir_network)
+teosd_process, teos_id = run_teosd(teos_config, teos_datadir_network)
 
 try:
     user_sk, user_id = teos_cli.load_keys(cli_config.get("CLI_PRIVATE_KEY"))
@@ -514,7 +514,7 @@ def test_appointment_shutdown_teos_trigger_back_online(bitcoin_cli):
 
     # Restart teos
     teosd_process.terminate()
-    teosd_process, _ = run_teosd(teos_datadir_network)
+    teosd_process, _ = run_teosd(teos_config, teos_datadir_network)
 
     assert teos_pid != teosd_process.pid
 
@@ -559,7 +559,7 @@ def test_appointment_shutdown_teos_trigger_while_offline(bitcoin_cli):
     broadcast_transaction_and_mine_block(bitcoin_cli, commitment_tx, new_addr)
 
     # Restart
-    teosd_process, _ = run_teosd(teos_datadir_network)
+    teosd_process, _ = run_teosd(teos_config, teos_datadir_network)
     assert teos_pid != teosd_process.pid
 
     # The appointment should have been moved to the Responder


### PR DESCRIPTION
Adds a "daemon" flag to the config that detaches the current shell in order to run in background.
Uses the [python-daemon](https://pypi.org/project/python-daemon/) library, which is therefore added to the requirements.

In this current version, there is no way to interact with the background daemon (for example to terminate it). That could be done together (or after) #146.

Closes: #172