### PR TITLE
Refactor tests so they can be ran individually

### DIFF
--- a/test/teos/conftest.py
+++ b/test/teos/conftest.py
@@ -35,7 +35,7 @@ def prng_seed():
     random.seed(0)
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def run_bitcoind(dirname=".test_bitcoin"):
     # Run bitcoind in a separate folder
     makedirs(dirname, exist_ok=True)

--- a/test/teos/unit/conftest.py
+++ b/test/teos/unit/conftest.py
@@ -51,12 +51,12 @@ def user_db_manager():
 
 
 @pytest.fixture(scope="module")
-def carrier():
+def carrier(run_bitcoind):
     return Carrier(bitcoind_connect_params)
 
 
 @pytest.fixture(scope="module")
-def block_processor():
+def block_processor(run_bitcoind):
     return BlockProcessor(bitcoind_connect_params)
 
 

--- a/test/teos/unit/test_api.py
+++ b/test/teos/unit/test_api.py
@@ -66,7 +66,7 @@ def get_all_db_manager():
     rmtree("get_all_tmp_db")
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="module")
 def internal_api(run_bitcoind, db_manager, gatekeeper, carrier, block_processor):
     responder = Responder(db_manager, gatekeeper, carrier, block_processor)
     watcher = Watcher(
@@ -199,10 +199,7 @@ def test_add_appointment(internal_api, client, appointment, block_processor):
     assert r.json.get("start_block") == block_processor.get_block_count()
 
 
-def test_add_appointment_no_json(internal_api, client, appointment):
-    # Simulate the user registration (end time does not matter here)
-    internal_api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=1, subscription_expiry=0)
-
+def test_add_appointment_no_json(client):
     # No JSON data
     r = client.post(add_appointment_endpoint, data="random_message")
     assert r.status_code == HTTP_BAD_REQUEST
@@ -210,10 +207,7 @@ def test_add_appointment_no_json(internal_api, client, appointment):
     assert errors.INVALID_REQUEST_FORMAT == r.json.get("error_code")
 
 
-def test_add_appointment_json_no_inner_dict(internal_api, client, appointment):
-    # Simulate the user registration (end time does not matter here)
-    internal_api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=1, subscription_expiry=0)
-
+def test_add_appointment_json_no_inner_dict(client):
     # JSON data with no inner dict (invalid data format)
     r = client.post(add_appointment_endpoint, json="random_message")
     assert r.status_code == HTTP_BAD_REQUEST
@@ -221,6 +215,7 @@ def test_add_appointment_json_no_inner_dict(internal_api, client, appointment):
     assert errors.INVALID_REQUEST_FORMAT == r.json.get("error_code")
 
 
+# FIXME: 194 will do with dummy appointment
 def test_add_appointment_wrong(internal_api, client, appointment):
     # Simulate the user registration (end time does not matter here)
     internal_api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=1, subscription_expiry=0)
@@ -233,7 +228,8 @@ def test_add_appointment_wrong(internal_api, client, appointment):
     assert errors.APPOINTMENT_FIELD_TOO_SMALL == r.json.get("error_code")
 
 
-def test_add_appointment_not_registered(client, appointment):
+# FIXME: 194 will do with dummy appointment
+def test_add_appointment_not_registered(internal_api, client, appointment):
     # Properly formatted appointment, user is not registered
     tmp_sk, tmp_pk = generate_keypair()
     tmp_compressed_pk = hexlify(tmp_pk.format(compressed=True)).decode("utf-8")
@@ -246,6 +242,7 @@ def test_add_appointment_not_registered(client, appointment):
     assert errors.APPOINTMENT_INVALID_SIGNATURE_OR_INSUFFICIENT_SLOTS == r.json.get("error_code")
 
 
+# FIXME: 194 will do with dummy appointment
 def test_add_appointment_registered_no_free_slots(internal_api, client, appointment):
     # Empty the user slots (end time does not matter here)
     internal_api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=0, subscription_expiry=0)
@@ -257,6 +254,7 @@ def test_add_appointment_registered_no_free_slots(internal_api, client, appointm
     assert errors.APPOINTMENT_INVALID_SIGNATURE_OR_INSUFFICIENT_SLOTS == r.json.get("error_code")
 
 
+# FIXME: 194 will do with dummy appointment
 def test_add_appointment_registered_not_enough_free_slots(internal_api, client, appointment):
     # Give some slots to the user (end time does not matter here)
     internal_api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=1, subscription_expiry=0)
@@ -272,6 +270,7 @@ def test_add_appointment_registered_not_enough_free_slots(internal_api, client, 
     assert errors.APPOINTMENT_INVALID_SIGNATURE_OR_INSUFFICIENT_SLOTS == r.json.get("error_code")
 
 
+# FIXME: 194 will do with dummy appointment and block_processor
 def test_add_appointment_multiple_times_same_user(
     internal_api, client, appointment, block_processor, n=MULTIPLE_APPOINTMENTS
 ):
@@ -290,6 +289,7 @@ def test_add_appointment_multiple_times_same_user(
     assert len(internal_api.watcher.locator_uuid_map[appointment.locator]) == 1
 
 
+# FIXME: 194 will do with dummy appointment and block_processor
 def test_add_appointment_multiple_times_different_users(
     internal_api, client, appointment, block_processor, n=MULTIPLE_APPOINTMENTS
 ):
@@ -317,6 +317,7 @@ def test_add_appointment_multiple_times_different_users(
     assert len(set(internal_api.watcher.locator_uuid_map[appointment.locator])) == n
 
 
+# FIXME: 194 will do with dummy appointment and block_processor
 def test_add_appointment_update_same_size(internal_api, client, appointment, block_processor):
     # Update an appointment by one of the same size and check that no additional slots are filled
     internal_api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=1, subscription_expiry=0)
@@ -341,6 +342,7 @@ def test_add_appointment_update_same_size(internal_api, client, appointment, blo
     )
 
 
+# FIXME: 194 will do with dummy appointment and block_processor
 def test_add_appointment_update_bigger(internal_api, client, appointment, block_processor):
     # Update an appointment by one bigger, and check additional slots are filled
     internal_api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=2, subscription_expiry=0)
@@ -367,6 +369,7 @@ def test_add_appointment_update_bigger(internal_api, client, appointment, block_
     assert r.status_code == HTTP_BAD_REQUEST
 
 
+# FIXME: 194 will do with dummy appointment and block_processor
 def test_add_appointment_update_smaller(internal_api, client, appointment, block_processor):
     # Update an appointment by one bigger, and check slots are freed
     internal_api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=2, subscription_expiry=0)
@@ -423,6 +426,7 @@ def test_add_appointment_in_cache_invalid_transaction(internal_api, client, bloc
     )
 
 
+# FIXME: 194 will do with dummy appointment and block processor
 def test_add_too_many_appointment(internal_api, client, block_processor, generate_dummy_appointment):
     # Give slots to the user
     internal_api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=200, subscription_expiry=0)
@@ -442,14 +446,14 @@ def test_add_too_many_appointment(internal_api, client, block_processor, generat
             assert r.status_code == HTTP_SERVICE_UNAVAILABLE
 
 
-def test_get_appointment_no_json(client, appointment):
+def test_get_appointment_no_json(client):
     r = client.post(add_appointment_endpoint, data="random_message")
     assert r.status_code == HTTP_BAD_REQUEST
     assert "Request is not json encoded" in r.json.get("error")
     assert errors.INVALID_REQUEST_FORMAT == r.json.get("error_code")
 
 
-def test_get_appointment_json_no_inner_dict(client, appointment):
+def test_get_appointment_json_no_inner_dict(client):
     r = client.post(add_appointment_endpoint, json="random_message")
     assert r.status_code == HTTP_BAD_REQUEST
     assert "Invalid request content" in r.json.get("error")
@@ -512,7 +516,8 @@ def test_get_appointment_in_watcher(internal_api, client, appointment, monkeypat
 def test_get_appointment_in_responder(internal_api, client, generate_dummy_tracker, monkeypatch):
     tx_tracker = generate_dummy_tracker()
 
-    uuid = hash_160("{}{}".format(appointment.locator, user_id))
+    # Mock the appointment in the Responder
+    uuid = hash_160("{}{}".format(tx_tracker.locator, user_id))
     internal_api.watcher.responder.trackers[uuid] = tx_tracker.get_summary()
     internal_api.watcher.responder.db_manager.store_responder_tracker(uuid, tx_tracker.to_dict())
 
@@ -520,9 +525,9 @@ def test_get_appointment_in_responder(internal_api, client, generate_dummy_track
     monkeypatch.setattr(internal_api.watcher.gatekeeper, "authenticate_user", mock_authenticate_user)
 
     # Request back the data
-    message = "get appointment {}".format(appointment.locator)
+    message = "get appointment {}".format(tx_tracker.locator)
     signature = Cryptographer.sign(message.encode("utf-8"), user_sk)
-    data = {"locator": appointment.locator, "signature": signature}
+    data = {"locator": tx_tracker.locator, "signature": signature}
 
     # Next we can request it
     r = client.post(get_appointment_endpoint, json=data)

--- a/test/teos/unit/test_api.py
+++ b/test/teos/unit/test_api.py
@@ -62,7 +62,7 @@ def get_all_db_manager():
 
 
 @pytest.fixture(scope="module", autouse=True)
-def internal_api(db_manager, gatekeeper, carrier, block_processor):
+def internal_api(run_bitcoind, db_manager, gatekeeper, carrier, block_processor):
     responder = Responder(db_manager, gatekeeper, carrier, block_processor)
     watcher = Watcher(
         db_manager, gatekeeper, block_processor, responder, teos_sk, MAX_APPOINTMENTS, config.get("LOCATOR_CACHE_SIZE")
@@ -474,6 +474,7 @@ def test_get_appointment_not_registered_user(client):
     test_get_random_appointment_registered_user(client, tmp_sk)
 
 
+# TODO: depends on previous test
 def test_get_appointment_in_watcher(internal_api, client, appointment):
     # Mock the appointment in the Watcher
     uuid = hash_160("{}{}".format(appointment.locator, user_id))
@@ -499,6 +500,7 @@ def test_get_appointment_in_watcher(internal_api, client, appointment):
     assert appointment.to_dict() == r.json.get("appointment")
 
 
+# TODO: depends on previous test
 def test_get_appointment_in_responder(internal_api, client, appointment):
     # Mock the appointment in the Responder
     tracker_data = {

--- a/test/teos/unit/test_api.py
+++ b/test/teos/unit/test_api.py
@@ -50,6 +50,11 @@ teos_sk, teos_pk = generate_keypair()
 teos_id = hexlify(teos_pk.format(compressed=True)).decode("utf-8")
 
 
+# A function that ignores the arguments and returns user_id; used in some tests to mock the result of authenticate_user
+def mock_authenticate_user(*args, **kwargs):
+    return user_id
+
+
 @pytest.fixture()
 def get_all_db_manager():
     manager = AppointmentsDBM("get_all_tmp_db")
@@ -482,9 +487,6 @@ def test_get_appointment_in_watcher(internal_api, client, appointment, monkeypat
     internal_api.watcher.appointments[uuid] = extended_appointment_summary
     internal_api.watcher.db_manager.store_watcher_appointment(uuid, appointment.to_dict())
 
-    def mock_authenticate_user(*args, **kwargs):
-        return user_id
-
     # mock the gatekeeper (user won't be registered if the previous tests weren't ran)
     monkeypatch.setattr(internal_api.watcher.gatekeeper, "authenticate_user", mock_authenticate_user)
 
@@ -513,9 +515,6 @@ def test_get_appointment_in_responder(internal_api, client, generate_dummy_track
     uuid = hash_160("{}{}".format(appointment.locator, user_id))
     internal_api.watcher.responder.trackers[uuid] = tx_tracker.get_summary()
     internal_api.watcher.responder.db_manager.store_responder_tracker(uuid, tx_tracker.to_dict())
-
-    def mock_authenticate_user(*args, **kwargs):
-        return user_id
 
     # mock the gatekeeper (user won't be registered if the previous tests weren't ran)
     monkeypatch.setattr(internal_api.watcher.gatekeeper, "authenticate_user", mock_authenticate_user)

--- a/test/teos/unit/test_api.py
+++ b/test/teos/unit/test_api.py
@@ -14,7 +14,7 @@ from teos.appointments_dbm import AppointmentsDBM
 from teos.responder import Responder, TransactionTracker
 
 from test.teos.conftest import config, create_txs
-from test.teos.unit.conftest import get_random_value_hex, generate_dummy_appointment, generate_keypair, compute_locator
+from test.teos.unit.conftest import get_random_value_hex, generate_keypair, compute_locator
 
 import common.receipts as receipts
 from common.cryptographer import Cryptographer, hash_160
@@ -101,7 +101,7 @@ def client(app):
 
 
 @pytest.fixture
-def appointment():
+def appointment(generate_dummy_appointment):
     appointment, dispute_tx = generate_dummy_appointment()
     locator_dispute_tx_map[appointment.locator] = dispute_tx
 
@@ -423,7 +423,7 @@ def test_add_appointment_in_cache_invalid_transaction(internal_api, client, bloc
     )
 
 
-def test_add_too_many_appointment(internal_api, client, block_processor):
+def test_add_too_many_appointment(internal_api, client, block_processor, generate_dummy_appointment):
     # Give slots to the user
     internal_api.watcher.gatekeeper.registered_users[user_id] = UserInfo(available_slots=200, subscription_expiry=0)
 

--- a/test/teos/unit/test_appointments_dbm.py
+++ b/test/teos/unit/test_appointments_dbm.py
@@ -18,7 +18,7 @@ from test.teos.unit.conftest import get_random_value_hex, generate_dummy_appoint
 
 
 @pytest.fixture(scope="module")
-def watcher_appointments():
+def watcher_appointments(run_bitcoind):
     return {uuid4().hex: generate_dummy_appointment()[0] for _ in range(10)}
 
 
@@ -164,6 +164,7 @@ def test_update_locator_map_empty(db_manager):
     assert locator_map_after == locator_map
 
 
+# TODO: depends on previous test
 def test_delete_locator_map(db_manager):
     locator_maps = db_manager.load_appointments_db(prefix=LOCATOR_MAP_PREFIX)
     assert len(locator_maps) != 0
@@ -208,7 +209,7 @@ def test_store_load_watcher_appointment(db_manager, watcher_appointments):
         assert appointment.to_dict() == db_watcher_appointments[uuid]
 
 
-def test_store_load_triggered_appointment(db_manager):
+def test_store_load_triggered_appointment(run_bitcoind, db_manager):
     db_watcher_appointments = db_manager.load_watcher_appointments()
     db_watcher_appointments_with_triggered = db_manager.load_watcher_appointments(include_triggered=True)
 
@@ -251,6 +252,7 @@ def test_store_load_responder_trackers(db_manager, responder_trackers):
     assert set(responder_trackers.values()) == set(values) and len(responder_trackers) == len(values)
 
 
+# TODO: depends on previous test
 def test_delete_watcher_appointment(db_manager, watcher_appointments):
     # Let's delete all we added
     db_watcher_appointments = db_manager.load_watcher_appointments(include_triggered=True)
@@ -289,6 +291,7 @@ def test_batch_delete_watcher_appointments(db_manager, watcher_appointments):
     assert not db_watcher_appointments
 
 
+# TODO: depends on previous test
 def test_delete_responder_tracker(db_manager, responder_trackers):
     # Same for the responder
     db_responder_trackers = db_manager.load_responder_trackers()

--- a/test/teos/unit/test_appointments_dbm.py
+++ b/test/teos/unit/test_appointments_dbm.py
@@ -14,7 +14,7 @@ from teos.appointments_dbm import (
 
 from common.constants import LOCATOR_LEN_BYTES
 
-from test.teos.unit.conftest import get_random_value_hex, generate_dummy_appointment
+from test.teos.unit.conftest import get_random_value_hex, generate_dummy_appointment, generate_dummy_tracker
 
 
 @pytest.fixture(scope="module")
@@ -23,8 +23,8 @@ def watcher_appointments(run_bitcoind):
 
 
 @pytest.fixture(scope="module")
-def responder_trackers():
-    return {get_random_value_hex(16): get_random_value_hex(32) for _ in range(10)}
+def responder_trackers(run_bitcoind):
+    return {uuid4().hex: generate_dummy_tracker().locator for _ in range(10)}
 
 
 def open_create_db(db_path):

--- a/test/teos/unit/test_appointments_dbm.py
+++ b/test/teos/unit/test_appointments_dbm.py
@@ -17,11 +17,13 @@ from common.constants import LOCATOR_LEN_BYTES
 from test.teos.unit.conftest import get_random_value_hex
 
 
+# FIXME: 194 will do with dummy appointments
 @pytest.fixture(scope="module")
 def watcher_appointments(generate_dummy_appointment):
     return {uuid4().hex: generate_dummy_appointment()[0] for _ in range(10)}
 
 
+# FIXME: 194 will do with dummy trackers
 @pytest.fixture(scope="module")
 def responder_trackers(generate_dummy_tracker):
     return {uuid4().hex: generate_dummy_tracker().locator for _ in range(10)}

--- a/test/teos/unit/test_appointments_dbm.py
+++ b/test/teos/unit/test_appointments_dbm.py
@@ -14,16 +14,16 @@ from teos.appointments_dbm import (
 
 from common.constants import LOCATOR_LEN_BYTES
 
-from test.teos.unit.conftest import get_random_value_hex, generate_dummy_appointment, generate_dummy_tracker
+from test.teos.unit.conftest import get_random_value_hex
 
 
 @pytest.fixture(scope="module")
-def watcher_appointments(run_bitcoind):
+def watcher_appointments(generate_dummy_appointment):
     return {uuid4().hex: generate_dummy_appointment()[0] for _ in range(10)}
 
 
 @pytest.fixture(scope="module")
-def responder_trackers(run_bitcoind):
+def responder_trackers(generate_dummy_tracker):
     return {uuid4().hex: generate_dummy_tracker().locator for _ in range(10)}
 
 
@@ -220,7 +220,7 @@ def test_store_load_watcher_appointment(db_manager, watcher_appointments):
         assert appointment.to_dict() == db_watcher_appointments[uuid]
 
 
-def test_store_load_triggered_appointment(run_bitcoind, db_manager):
+def test_store_load_triggered_appointment(generate_dummy_appointment, db_manager):
     db_watcher_appointments = db_manager.load_watcher_appointments()
     db_watcher_appointments_with_triggered = db_manager.load_watcher_appointments(include_triggered=True)
 

--- a/test/teos/unit/test_appointments_dbm.py
+++ b/test/teos/unit/test_appointments_dbm.py
@@ -164,9 +164,20 @@ def test_update_locator_map_empty(db_manager):
     assert locator_map_after == locator_map
 
 
-# TODO: depends on previous test
 def test_delete_locator_map(db_manager):
     locator_maps = db_manager.load_appointments_db(prefix=LOCATOR_MAP_PREFIX)
+
+    # Make sure there are some locators before starting the test
+    # (needed so that the test can be ran individually from the others)
+    if not locator_maps:
+        for _ in range(5):
+            uuid = uuid4().hex
+            locator = get_random_value_hex(LOCATOR_LEN_BYTES)
+            db_manager.create_append_locator_map(locator, uuid)
+
+        locator_maps = db_manager.load_appointments_db(prefix=LOCATOR_MAP_PREFIX)
+
+    # Now that there are some locators, we can start the test
     assert len(locator_maps) != 0
 
     for locator, uuids in locator_maps.items():
@@ -252,8 +263,14 @@ def test_store_load_responder_trackers(db_manager, responder_trackers):
     assert set(responder_trackers.values()) == set(values) and len(responder_trackers) == len(values)
 
 
-# TODO: depends on previous test
 def test_delete_watcher_appointment(db_manager, watcher_appointments):
+    # make sure that some appointments were added
+    # (needed in case the test is ran individually rather than as part of the suite)
+    db_watcher_appointments = db_manager.load_watcher_appointments(include_triggered=True)
+    if not db_watcher_appointments:
+        for uuid, appointment in watcher_appointments.items():
+            db_manager.store_watcher_appointment(uuid, appointment.to_dict())
+
     # Let's delete all we added
     db_watcher_appointments = db_manager.load_watcher_appointments(include_triggered=True)
     assert len(db_watcher_appointments) != 0
@@ -291,8 +308,14 @@ def test_batch_delete_watcher_appointments(db_manager, watcher_appointments):
     assert not db_watcher_appointments
 
 
-# TODO: depends on previous test
 def test_delete_responder_tracker(db_manager, responder_trackers):
+    # make sure that some trackers were added
+    # (needed in case the test is ran individually rather than as part of the suite)
+    db_responder_trackers = db_manager.load_responder_trackers()
+    if not db_responder_trackers:
+        for key, value in responder_trackers.items():
+            db_manager.store_responder_tracker(key, {"value": value})
+
     # Same for the responder
     db_responder_trackers = db_manager.load_responder_trackers()
     assert len(db_responder_trackers) != 0

--- a/test/teos/unit/test_builder.py
+++ b/test/teos/unit/test_builder.py
@@ -10,6 +10,7 @@ from test.teos.conftest import config, generate_blocks
 from test.teos.unit.conftest import get_random_value_hex, generate_keypair
 
 
+# FIXME: 194 will do with dummy appointment
 def test_build_appointments(generate_dummy_appointment):
     appointments_data = {}
 
@@ -40,6 +41,7 @@ def test_build_appointments(generate_dummy_appointment):
         assert uuid in locator_uuid_map[appointment.get("locator")]
 
 
+# FIXME: 194 will do with dummy tracker
 def test_build_trackers(generate_dummy_tracker):
     trackers_data = {}
 
@@ -106,6 +108,7 @@ def test_update_states_empty_list(db_manager, gatekeeper, carrier, block_process
         Builder.update_states(w, missed_blocks_responder, missed_blocks_watcher)
 
 
+# FIXME: 194 will do with watcher, since no functionality is being used, this is only populating the data structures
 def test_update_states_responder_misses_more(db_manager, gatekeeper, carrier, block_processor):
     w = Watcher(
         db_manager=db_manager,
@@ -128,6 +131,7 @@ def test_update_states_responder_misses_more(db_manager, gatekeeper, carrier, bl
     assert w.responder.last_known_block == blocks[-1]
 
 
+# FIXME: 194 will do with watcher, since no functionality is being used, this is only populating the data structures
 def test_update_states_watcher_misses_more(db_manager, gatekeeper, carrier, block_processor):
     # Same as before, but data is now in the Responder
     w = Watcher(

--- a/test/teos/unit/test_builder.py
+++ b/test/teos/unit/test_builder.py
@@ -7,15 +7,10 @@ from teos.watcher import Watcher
 from teos.responder import Responder
 
 from test.teos.conftest import config, generate_blocks
-from test.teos.unit.conftest import (
-    get_random_value_hex,
-    generate_dummy_appointment,
-    generate_dummy_tracker,
-    generate_keypair,
-)
+from test.teos.unit.conftest import get_random_value_hex, generate_keypair
 
 
-def test_build_appointments(run_bitcoind):
+def test_build_appointments(generate_dummy_appointment):
     appointments_data = {}
 
     # Create some appointment data
@@ -45,7 +40,7 @@ def test_build_appointments(run_bitcoind):
         assert uuid in locator_uuid_map[appointment.get("locator")]
 
 
-def test_build_trackers(run_bitcoind):
+def test_build_trackers(generate_dummy_tracker):
     trackers_data = {}
 
     # Create some trackers data

--- a/test/teos/unit/test_builder.py
+++ b/test/teos/unit/test_builder.py
@@ -15,7 +15,7 @@ from test.teos.unit.conftest import (
 )
 
 
-def test_build_appointments():
+def test_build_appointments(run_bitcoind):
     appointments_data = {}
 
     # Create some appointment data
@@ -45,7 +45,7 @@ def test_build_appointments():
         assert uuid in locator_uuid_map[appointment.get("locator")]
 
 
-def test_build_trackers():
+def test_build_trackers(run_bitcoind):
     trackers_data = {}
 
     # Create some trackers data

--- a/test/teos/unit/test_chain_monitor.py
+++ b/test/teos/unit/test_chain_monitor.py
@@ -63,7 +63,7 @@ def test_update_state(block_processor):
     assert chain_monitor.best_tip == another_block_hash and new_block_hash == chain_monitor.last_tips[-1]
 
 
-def test_monitor_chain_polling(db_manager, block_processor):
+def test_monitor_chain_polling(block_processor):
     # Try polling with the Watcher
     watcher_queue = Queue()
     chain_monitor = ChainMonitor(watcher_queue, Queue(), block_processor, bitcoind_feed_params)
@@ -88,7 +88,7 @@ def test_monitor_chain_polling(db_manager, block_processor):
     chain_monitor.terminate = True
 
 
-def test_monitor_chain_zmq(db_manager, block_processor):
+def test_monitor_chain_zmq(block_processor):
     responder_queue = Queue()
     chain_monitor = ChainMonitor(Queue(), responder_queue, block_processor, bitcoind_feed_params)
     chain_monitor.best_tip = block_processor.get_best_block_hash()
@@ -111,7 +111,7 @@ def test_monitor_chain_zmq(db_manager, block_processor):
     generate_blocks(1)
 
 
-def test_monitor_chain(db_manager, block_processor):
+def test_monitor_chain(block_processor):
     # Not much to test here, this should launch two threads (one per monitor approach) and finish on terminate
     chain_monitor = ChainMonitor(Queue(), Queue(), block_processor, bitcoind_feed_params)
     chain_monitor.monitor_chain()
@@ -133,7 +133,7 @@ def test_monitor_chain(db_manager, block_processor):
     generate_blocks(1)
 
 
-def test_monitor_chain_single_update(db_manager, block_processor):
+def test_monitor_chain_single_update(block_processor):
     # This test tests that if both threads try to add the same block to the queue, only the first one will make it
     chain_monitor = ChainMonitor(Queue(), Queue(), block_processor, bitcoind_feed_params)
 

--- a/test/teos/unit/test_cleaner.py
+++ b/test/teos/unit/test_cleaner.py
@@ -15,7 +15,7 @@ ITEMS = 10
 MAX_ITEMS = 100
 ITERATIONS = 10
 
-
+# FIXME: 194 this is using the dummiest appointment, can be updated with the fixture once it's implemented
 def set_up_appointments(db_manager, total_appointments):
     appointments = dict()
     locator_uuid_map = dict()
@@ -44,6 +44,7 @@ def set_up_appointments(db_manager, total_appointments):
     return appointments, locator_uuid_map
 
 
+# FIXME: 194 this is using the dummiest tracker, can be updated with the fixture once it's implemented
 def set_up_trackers(db_manager, total_trackers):
     trackers = dict()
     tx_tracker_map = dict()
@@ -209,6 +210,7 @@ def test_delete_trackers_no_db_match(db_manager):
         assert not set(completed_trackers).issubset(trackers.keys())
 
 
+# FIXME: 194 will do with dummy gatekeeper since this is only deleting data from the structures
 def test_delete_gatekeeper_appointments(gatekeeper):
     # delete_gatekeeper_appointments should delete the appointments from user as long as both exist
 

--- a/test/teos/unit/test_gatekeeper.py
+++ b/test/teos/unit/test_gatekeeper.py
@@ -9,7 +9,7 @@ from common.exceptions import InvalidParameter
 from common.constants import ENCRYPTED_BLOB_MAX_SIZE_HEX
 
 from test.teos.conftest import config
-from test.teos.unit.conftest import get_random_value_hex, generate_keypair, generate_dummy_appointment
+from test.teos.unit.conftest import get_random_value_hex, generate_keypair
 
 
 def test_init(gatekeeper):
@@ -151,7 +151,7 @@ def test_identify_user_wrong(gatekeeper):
         gatekeeper.authenticate_user(message, signature.encode())
 
 
-def test_add_update_appointment(gatekeeper):
+def test_add_update_appointment(gatekeeper, generate_dummy_appointment):
     # add_update_appointment should decrease the slot count if a new appointment is added
     # let's add a new user
     sk, pk = generate_keypair()

--- a/test/teos/unit/test_gatekeeper.py
+++ b/test/teos/unit/test_gatekeeper.py
@@ -12,6 +12,7 @@ from test.teos.conftest import config
 from test.teos.unit.conftest import get_random_value_hex, generate_keypair
 
 
+# FIXME: 194 this whole test file could work with a gatekeeper build using a dummy block_processor
 def test_init(gatekeeper):
     assert isinstance(gatekeeper.subscription_slots, int) and gatekeeper.subscription_slots == config.get(
         "SUBSCRIPTION_SLOTS"
@@ -151,6 +152,7 @@ def test_identify_user_wrong(gatekeeper):
         gatekeeper.authenticate_user(message, signature.encode())
 
 
+# FIXME: 194 will do with dummy appointment
 def test_add_update_appointment(gatekeeper, generate_dummy_appointment):
     # add_update_appointment should decrease the slot count if a new appointment is added
     # let's add a new user

--- a/test/teos/unit/test_inspector.py
+++ b/test/teos/unit/test_inspector.py
@@ -33,7 +33,7 @@ MIN_TO_SELF_DELAY = config.get("MIN_TO_SELF_DELAY")
 inspector = Inspector(MIN_TO_SELF_DELAY)
 
 
-def test_check_locator():
+def test_check_locator(run_bitcoind):
     # Right appointment type, size and format
     locator = get_random_value_hex(LOCATOR_LEN_BYTES)
     assert inspector.check_locator(locator) is None
@@ -92,7 +92,7 @@ def test_check_locator():
                 raise e
 
 
-def test_check_to_self_delay():
+def test_check_to_self_delay(run_bitcoind):
     # Right value, right format
     to_self_delays = [MIN_TO_SELF_DELAY, MIN_TO_SELF_DELAY + 1, MIN_TO_SELF_DELAY + 1000]
     for to_self_delay in to_self_delays:
@@ -131,7 +131,7 @@ def test_check_to_self_delay():
                 raise e
 
 
-def test_check_blob():
+def test_check_blob(run_bitcoind):
     # Right format and length
     encrypted_blob = get_random_value_hex(120)
     assert inspector.check_blob(encrypted_blob) is None
@@ -169,7 +169,7 @@ def test_check_blob():
                 raise e
 
 
-def test_inspect():
+def test_inspect(run_bitcoind):
     # Valid appointment
     locator = get_random_value_hex(LOCATOR_LEN_BYTES)
     to_self_delay = MIN_TO_SELF_DELAY
@@ -186,7 +186,7 @@ def test_inspect():
     )
 
 
-def test_inspect_wrong():
+def test_inspect_wrong(run_bitcoind):
     # Wrong types (taking out empty dict, since that's a different error)
     wrong_types = WRONG_TYPES.pop(WRONG_TYPES.index({}))
     for data in wrong_types:

--- a/test/teos/unit/test_inspector.py
+++ b/test/teos/unit/test_inspector.py
@@ -169,7 +169,7 @@ def test_check_blob():
                 raise e
 
 
-def test_inspect(run_bitcoind):
+def test_inspect():
     # Valid appointment
     locator = get_random_value_hex(LOCATOR_LEN_BYTES)
     to_self_delay = MIN_TO_SELF_DELAY
@@ -186,7 +186,7 @@ def test_inspect(run_bitcoind):
     )
 
 
-def test_inspect_wrong(run_bitcoind):
+def test_inspect_wrong():
     # Wrong types (taking out empty dict, since that's a different error)
     wrong_types = WRONG_TYPES.pop(WRONG_TYPES.index({}))
     for data in wrong_types:

--- a/test/teos/unit/test_inspector.py
+++ b/test/teos/unit/test_inspector.py
@@ -33,7 +33,7 @@ MIN_TO_SELF_DELAY = config.get("MIN_TO_SELF_DELAY")
 inspector = Inspector(MIN_TO_SELF_DELAY)
 
 
-def test_check_locator(run_bitcoind):
+def test_check_locator():
     # Right appointment type, size and format
     locator = get_random_value_hex(LOCATOR_LEN_BYTES)
     assert inspector.check_locator(locator) is None
@@ -92,7 +92,7 @@ def test_check_locator(run_bitcoind):
                 raise e
 
 
-def test_check_to_self_delay(run_bitcoind):
+def test_check_to_self_delay():
     # Right value, right format
     to_self_delays = [MIN_TO_SELF_DELAY, MIN_TO_SELF_DELAY + 1, MIN_TO_SELF_DELAY + 1000]
     for to_self_delay in to_self_delays:
@@ -131,7 +131,7 @@ def test_check_to_self_delay(run_bitcoind):
                 raise e
 
 
-def test_check_blob(run_bitcoind):
+def test_check_blob():
     # Right format and length
     encrypted_blob = get_random_value_hex(120)
     assert inspector.check_blob(encrypted_blob) is None

--- a/test/teos/unit/test_internal_api.py
+++ b/test/teos/unit/test_internal_api.py
@@ -92,6 +92,7 @@ def test_register_wrong_user_id(internal_api, stub):
     assert "Provided public key does not match expected format" in e.value.details()
 
 
+# FIXME: 194 will do with dummy appointment
 def test_add_appointment(internal_api, stub, generate_dummy_appointment):
     # Normal request should work just fine (user needs to be registered)
     stub.register(RegisterRequest(user_id=user_id))
@@ -103,6 +104,7 @@ def test_add_appointment(internal_api, stub, generate_dummy_appointment):
     assert isinstance(response, AddAppointmentResponse)
 
 
+# FIXME: 194 will do with dummy appointment
 def test_add_appointment_non_registered(internal_api, stub, generate_dummy_appointment):
     # If the user is not registered we should get UNAUTHENTICATED + the proper message
     another_user_sk, another_user_pk = generate_keypair()
@@ -115,6 +117,7 @@ def test_add_appointment_non_registered(internal_api, stub, generate_dummy_appoi
     assert "Invalid signature or user does not have enough slots available" in e.value.details()
 
 
+# FIXME: 194 will do with dummy appointment
 def test_add_appointment_not_enough_slots(internal_api, stub, generate_dummy_appointment):
     # UNAUTHENTICATED should also be get if the user does not have enough appointment slots
     # Register the user and set the slots to 0
@@ -130,6 +133,7 @@ def test_add_appointment_not_enough_slots(internal_api, stub, generate_dummy_app
     assert "Invalid signature or user does not have enough slots available" in e.value.details()
 
 
+# FIXME: 194 will do with dummy appointment
 def test_add_appointment_limit_reached(internal_api, stub, generate_dummy_appointment, monkeypatch):
     # If the tower appointment limit is reached RESOURCE_EXHAUSTED should be returned
     monkeypatch.setattr(internal_api.watcher, "max_appointments", 0)
@@ -145,6 +149,7 @@ def test_add_appointment_limit_reached(internal_api, stub, generate_dummy_appoin
     assert "Appointment limit reached" in e.value.details()
 
 
+# FIXME: 194 will do with dummy appointment
 def test_add_appointment_already_triggered(internal_api, stub, generate_dummy_appointment):
     # If the appointment has already been trigger we should get ALREADY_EXISTS
     stub.register(RegisterRequest(user_id=user_id))
@@ -161,6 +166,7 @@ def test_add_appointment_already_triggered(internal_api, stub, generate_dummy_ap
     assert "The provided appointment has already been triggered" in e.value.details()
 
 
+# FIXME: 194 will do with dummy appointment
 def test_get_appointment(internal_api, stub, generate_dummy_appointment):
     # Requests should work provided the user is registered and the appointment exists for him
     stub.register(RegisterRequest(user_id=user_id))
@@ -178,6 +184,7 @@ def test_get_appointment(internal_api, stub, generate_dummy_appointment):
     assert isinstance(response, GetAppointmentResponse)
 
 
+# FIXME: 194 will do with dummy appointment
 def test_get_appointment_non_registered(internal_api, stub, generate_dummy_appointment):
     # If the user is not registered or the appointment does not belong to him the response should be NOT_FOUND
     stub.register(RegisterRequest(user_id=user_id))

--- a/test/teos/unit/test_responder.py
+++ b/test/teos/unit/test_responder.py
@@ -22,7 +22,7 @@ from test.teos.conftest import (
     create_commitment_tx,
     generate_block_with_transactions,
 )
-from test.teos.unit.conftest import get_random_value_hex, bitcoind_feed_params, generate_dummy_tracker
+from test.teos.unit.conftest import get_random_value_hex, bitcoind_feed_params
 
 
 @pytest.fixture(scope="module")
@@ -63,7 +63,7 @@ def test_tracker_init():
     )
 
 
-def test_tracker_to_dict(run_bitcoind):
+def test_tracker_to_dict(generate_dummy_tracker):
     tracker = generate_dummy_tracker()
     tracker_dict = tracker.to_dict()
 
@@ -76,14 +76,14 @@ def test_tracker_to_dict(run_bitcoind):
     )
 
 
-def test_tracker_from_dict(run_bitcoind):
+def test_tracker_from_dict(generate_dummy_tracker):
     tracker_dict = generate_dummy_tracker().to_dict()
     new_tracker = TransactionTracker.from_dict(tracker_dict)
 
     assert tracker_dict == new_tracker.to_dict()
 
 
-def test_tracker_from_dict_invalid_data(run_bitcoind):
+def test_tracker_from_dict_invalid_data(generate_dummy_tracker):
     tracker_dict = generate_dummy_tracker().to_dict()
 
     for value in ["locator", "dispute_txid", "penalty_txid", "penalty_rawtx", "user_id"]:
@@ -94,7 +94,7 @@ def test_tracker_from_dict_invalid_data(run_bitcoind):
             TransactionTracker.from_dict(tracker_dict_copy)
 
 
-def test_tracker_get_summary(run_bitcoind):
+def test_tracker_get_summary(generate_dummy_tracker):
     tracker = generate_dummy_tracker()
     assert tracker.get_summary() == {
         "locator": tracker.locator,
@@ -134,7 +134,7 @@ def test_on_sync_fail(responder, block_processor):
     assert responder.on_sync(chain_tip) is False
 
 
-def test_handle_breach(db_manager, gatekeeper, carrier, block_processor):
+def test_handle_breach(db_manager, gatekeeper, carrier, block_processor, generate_dummy_tracker):
     responder = Responder(db_manager, gatekeeper, carrier, block_processor)
 
     uuid = uuid4().hex
@@ -156,7 +156,7 @@ def test_handle_breach(db_manager, gatekeeper, carrier, block_processor):
     assert receipt.delivered is True
 
 
-def test_handle_breach_bad_response(db_manager, gatekeeper, carrier, block_processor):
+def test_handle_breach_bad_response(db_manager, gatekeeper, carrier, block_processor, generate_dummy_tracker):
     # We need a new carrier here, otherwise the transaction will be flagged as previously sent and receipt.delivered
     # will be True
     responder = Responder(db_manager, gatekeeper, carrier, block_processor)
@@ -180,7 +180,7 @@ def test_handle_breach_bad_response(db_manager, gatekeeper, carrier, block_proce
     assert receipt.delivered is False
 
 
-def test_add_tracker(responder):
+def test_add_tracker(responder, generate_dummy_tracker):
     for _ in range(20):
         uuid = uuid4().hex
         confirmations = 0
@@ -214,7 +214,7 @@ def test_add_tracker(responder):
         )
 
 
-def test_add_tracker_same_penalty_txid(responder):
+def test_add_tracker_same_penalty_txid(responder, generate_dummy_tracker):
     # Test that multiple trackers with the same penalty can be added
     confirmations = 0
     tracker = generate_dummy_tracker()
@@ -254,7 +254,7 @@ def test_add_tracker_same_penalty_txid(responder):
         )
 
 
-def test_add_tracker_already_confirmed(responder):
+def test_add_tracker_already_confirmed(responder, generate_dummy_tracker):
     # Tests that a tracker of an already confirmed penalty can be added
     for i in range(20):
         uuid = uuid4().hex
@@ -279,7 +279,7 @@ def test_add_tracker_already_confirmed(responder):
         )
 
 
-def test_do_watch(temp_db_manager, gatekeeper, carrier, block_processor):
+def test_do_watch(temp_db_manager, gatekeeper, carrier, block_processor, generate_dummy_tracker):
     commitment_txs = [create_commitment_tx() for _ in range(20)]
     trackers = [generate_dummy_tracker(commitment_tx) for commitment_tx in commitment_txs]
     subscription_expiry = block_processor.get_block_count() + 110
@@ -406,7 +406,7 @@ def test_get_txs_to_rebroadcast(responder):
     assert txs_to_rebroadcast == list(txs_missing_too_many_conf.keys())
 
 
-def test_get_completed_trackers(db_manager, gatekeeper, carrier, block_processor):
+def test_get_completed_trackers(db_manager, gatekeeper, carrier, block_processor, generate_dummy_tracker):
     responder = Responder(db_manager, gatekeeper, carrier, block_processor)
     chain_monitor = ChainMonitor(Queue(), responder.block_queue, block_processor, bitcoind_feed_params)
     chain_monitor.monitor_chain()
@@ -459,7 +459,7 @@ def test_get_completed_trackers(db_manager, gatekeeper, carrier, block_processor
     assert set(completed_trackers) == set(ended_trackers_keys)
 
 
-def test_get_expired_trackers(responder):
+def test_get_expired_trackers(responder, generate_dummy_tracker):
     # Expired trackers are those whose subscription has reached the expiry block and have not been confirmed.
     # Confirmed trackers that have reached their expiry will be kept until completed
     current_block = responder.block_processor.get_block_count()
@@ -527,7 +527,7 @@ def test_get_expired_trackers(responder):
     )
 
 
-def test_rebroadcast(db_manager, gatekeeper, carrier, block_processor):
+def test_rebroadcast(db_manager, gatekeeper, carrier, block_processor, generate_dummy_tracker):
     responder = Responder(db_manager, gatekeeper, carrier, block_processor)
     chain_monitor = ChainMonitor(Queue(), responder.block_queue, block_processor, bitcoind_feed_params)
     chain_monitor.monitor_chain()

--- a/test/teos/unit/test_responder.py
+++ b/test/teos/unit/test_responder.py
@@ -63,7 +63,7 @@ def test_tracker_init():
     )
 
 
-def test_tracker_to_dict():
+def test_tracker_to_dict(run_bitcoind):
     tracker = generate_dummy_tracker()
     tracker_dict = tracker.to_dict()
 
@@ -76,14 +76,14 @@ def test_tracker_to_dict():
     )
 
 
-def test_tracker_from_dict():
+def test_tracker_from_dict(run_bitcoind):
     tracker_dict = generate_dummy_tracker().to_dict()
     new_tracker = TransactionTracker.from_dict(tracker_dict)
 
     assert tracker_dict == new_tracker.to_dict()
 
 
-def test_tracker_from_dict_invalid_data():
+def test_tracker_from_dict_invalid_data(run_bitcoind):
     tracker_dict = generate_dummy_tracker().to_dict()
 
     for value in ["locator", "dispute_txid", "penalty_txid", "penalty_rawtx", "user_id"]:
@@ -94,7 +94,7 @@ def test_tracker_from_dict_invalid_data():
             TransactionTracker.from_dict(tracker_dict_copy)
 
 
-def test_tracker_get_summary():
+def test_tracker_get_summary(run_bitcoind):
     tracker = generate_dummy_tracker()
     assert tracker.get_summary() == {
         "locator": tracker.locator,
@@ -413,7 +413,7 @@ def test_get_completed_trackers(db_manager, gatekeeper, carrier, block_processor
 
     commitment_txs = [create_commitment_tx() for _ in range(30)]
     generate_block_with_transactions(commitment_txs)
-    # A complete tracker is a tracker which penalty transaction has been irrevocably resolved (i.e. has reached 100
+    # A complete tracker is a tracker whose penalty transaction has been irrevocably resolved (i.e. has reached 100
     # confirmations)
     # We'll create 3 type of txs: irrevocably resolved, confirmed but not irrevocably resolved, and unconfirmed
     trackers_ir_resolved = {uuid4().hex: generate_dummy_tracker(commitment_tx) for commitment_tx in commitment_txs[:10]}
@@ -460,11 +460,11 @@ def test_get_completed_trackers(db_manager, gatekeeper, carrier, block_processor
 
 
 def test_get_expired_trackers(responder):
-    # Expired trackers are those who's subscription has reached the expiry block and have not been confirmed.
+    # Expired trackers are those whose subscription has reached the expiry block and have not been confirmed.
     # Confirmed trackers that have reached their expiry will be kept until completed
     current_block = responder.block_processor.get_block_count()
 
-    # Lets first register a couple of users
+    # Let's first register a couple of users
     user1_id = get_random_value_hex(16)
     responder.gatekeeper.registered_users[user1_id] = UserInfo(
         available_slots=10, subscription_expiry=current_block + 15

--- a/test/teos/unit/test_responder.py
+++ b/test/teos/unit/test_responder.py
@@ -34,6 +34,7 @@ def responder(db_manager, gatekeeper, carrier, block_processor):
     return responder
 
 
+# FIXME: Check if this can be removed and used the general fixture
 @pytest.fixture(scope="session")
 def temp_db_manager():
     db_name = get_random_value_hex(8)
@@ -63,6 +64,7 @@ def test_tracker_init():
     )
 
 
+# FIXME: 194 will do with dummy tracker
 def test_tracker_to_dict(generate_dummy_tracker):
     tracker = generate_dummy_tracker()
     tracker_dict = tracker.to_dict()
@@ -76,6 +78,7 @@ def test_tracker_to_dict(generate_dummy_tracker):
     )
 
 
+# FIXME: 194 will do with dummy tracker
 def test_tracker_from_dict(generate_dummy_tracker):
     tracker_dict = generate_dummy_tracker().to_dict()
     new_tracker = TransactionTracker.from_dict(tracker_dict)
@@ -83,6 +86,7 @@ def test_tracker_from_dict(generate_dummy_tracker):
     assert tracker_dict == new_tracker.to_dict()
 
 
+# FIXME: 194 will do with dummy tracker
 def test_tracker_from_dict_invalid_data(generate_dummy_tracker):
     tracker_dict = generate_dummy_tracker().to_dict()
 
@@ -94,6 +98,7 @@ def test_tracker_from_dict_invalid_data(generate_dummy_tracker):
             TransactionTracker.from_dict(tracker_dict_copy)
 
 
+# FIXME: 194 will do with dummy tracker
 def test_tracker_get_summary(generate_dummy_tracker):
     tracker = generate_dummy_tracker()
     assert tracker.get_summary() == {
@@ -180,6 +185,7 @@ def test_handle_breach_bad_response(db_manager, gatekeeper, carrier, block_proce
     assert receipt.delivered is False
 
 
+# FIXME: 194 will do with dummy tracker
 def test_add_tracker(responder, generate_dummy_tracker):
     for _ in range(20):
         uuid = uuid4().hex
@@ -214,6 +220,7 @@ def test_add_tracker(responder, generate_dummy_tracker):
         )
 
 
+# FIXME: 194 will do with dummy tracker
 def test_add_tracker_same_penalty_txid(responder, generate_dummy_tracker):
     # Test that multiple trackers with the same penalty can be added
     confirmations = 0
@@ -254,6 +261,7 @@ def test_add_tracker_same_penalty_txid(responder, generate_dummy_tracker):
         )
 
 
+# FIXME: 194 will do with dummy tracker
 def test_add_tracker_already_confirmed(responder, generate_dummy_tracker):
     # Tests that a tracker of an already confirmed penalty can be added
     for i in range(20):

--- a/test/teos/unit/test_rpc.py
+++ b/test/teos/unit/test_rpc.py
@@ -51,6 +51,7 @@ def test_get_all_appointments_empty():
     assert len(appointments.get("watcher_appointments")) == 0 and len(appointments.get("responder_trackers")) == 0
 
 
+# FIXME: 194 will do with dummy appointment
 def test_get_all_appointments_watcher(internal_api, generate_dummy_appointment):
     # Data is pulled straight from the database, so we need to feed some
     appointment, _ = generate_dummy_appointment()
@@ -64,7 +65,8 @@ def test_get_all_appointments_watcher(internal_api, generate_dummy_appointment):
     internal_api.watcher.db_manager.delete_watcher_appointment(uuid)
 
 
-def test_get_all_appointments_tracker(internal_api, generate_dummy_tracker):
+# FIXME: 194 will do with dummy tracker
+def test_get_all_appointments_responder(internal_api, generate_dummy_tracker):
     # Data is pulled straight from the database, so we need to feed some
     tracker = generate_dummy_tracker()
     uuid = uuid4().hex
@@ -77,6 +79,7 @@ def test_get_all_appointments_tracker(internal_api, generate_dummy_tracker):
     internal_api.watcher.db_manager.delete_responder_tracker(uuid)
 
 
+# FIXME: 194 will do with dummy appointments and trackers
 def test_get_all_appointments_both(internal_api, generate_dummy_appointment, generate_dummy_tracker):
     # Data is pulled straight from the database, so we need to feed some
     appointment, _ = generate_dummy_appointment()

--- a/test/teos/unit/test_rpc.py
+++ b/test/teos/unit/test_rpc.py
@@ -12,7 +12,7 @@ from teos.internal_api import InternalAPI
 from teos.teosd import INTERNAL_API_ENDPOINT
 
 from test.teos.conftest import config
-from test.teos.unit.conftest import generate_keypair, generate_dummy_appointment, generate_dummy_tracker
+from test.teos.unit.conftest import generate_keypair
 
 
 MAX_APPOINTMENTS = 100
@@ -51,7 +51,7 @@ def test_get_all_appointments_empty():
     assert len(appointments.get("watcher_appointments")) == 0 and len(appointments.get("responder_trackers")) == 0
 
 
-def test_get_all_appointments_watcher(internal_api):
+def test_get_all_appointments_watcher(internal_api, generate_dummy_appointment):
     # Data is pulled straight from the database, so we need to feed some
     appointment, _ = generate_dummy_appointment()
     uuid = uuid4().hex
@@ -64,7 +64,7 @@ def test_get_all_appointments_watcher(internal_api):
     internal_api.watcher.db_manager.delete_watcher_appointment(uuid)
 
 
-def test_get_all_appointments_tracker(internal_api):
+def test_get_all_appointments_tracker(internal_api, generate_dummy_tracker):
     # Data is pulled straight from the database, so we need to feed some
     tracker = generate_dummy_tracker()
     uuid = uuid4().hex
@@ -77,7 +77,7 @@ def test_get_all_appointments_tracker(internal_api):
     internal_api.watcher.db_manager.delete_responder_tracker(uuid)
 
 
-def test_get_all_appointments_both(internal_api):
+def test_get_all_appointments_both(internal_api, generate_dummy_appointment, generate_dummy_tracker):
     # Data is pulled straight from the database, so we need to feed some
     appointment, _ = generate_dummy_appointment()
     uuid_appointment = uuid4().hex

--- a/test/teos/unit/test_tools.py
+++ b/test/teos/unit/test_tools.py
@@ -6,7 +6,7 @@ from test.teos.unit.conftest import bitcoind_connect_params
 from common.constants import MAINNET_RPC_PORT, TESTNET_RPC_PORT, REGTEST_RPC_PORT
 
 
-def test_in_correct_network():
+def test_in_correct_network(run_bitcoind):
     # The simulator runs as if it was regtest, so every other network should fail
     assert in_correct_network(bitcoind_connect_params, "mainnet") is False
     assert in_correct_network(bitcoind_connect_params, "testnet") is False

--- a/test/teos/unit/test_watcher.py
+++ b/test/teos/unit/test_watcher.py
@@ -216,7 +216,7 @@ def test_update_cache_full():
         assert locator in locator_cache.cache
 
 
-def test_locator_cache_is_full(block_processor):
+def test_locator_cache_is_full():
     # Empty cache
     locator_cache = LocatorCache(config.get("LOCATOR_CACHE_SIZE"))
 
@@ -228,7 +228,7 @@ def test_locator_cache_is_full(block_processor):
     assert locator_cache.is_full()
 
 
-def test_locator_remove_oldest_block(block_processor):
+def test_locator_remove_oldest_block():
     # Empty cache
     locator_cache = LocatorCache(config.get("LOCATOR_CACHE_SIZE"))
 

--- a/test/teos/unit/test_watcher.py
+++ b/test/teos/unit/test_watcher.py
@@ -63,7 +63,7 @@ def temp_db_manager():
 
 
 @pytest.fixture(scope="module")
-def watcher(db_manager, gatekeeper):
+def watcher(run_bitcoind, db_manager, gatekeeper):
     block_processor = BlockProcessor(bitcoind_connect_params)
     carrier = Carrier(bitcoind_connect_params)
 
@@ -574,6 +574,7 @@ def test_do_watch(watcher, temp_db_manager):
     # FIXME: We should also add cases where the transactions are invalid. bitcoind_mock needs to be extended for this.
 
 
+# TODO: depends on previous test
 def test_do_watch_cache_update(watcher):
     # Test that data is properly added/remove to/from the cache
 

--- a/test/teos/unit/test_watcher.py
+++ b/test/teos/unit/test_watcher.py
@@ -97,6 +97,7 @@ def locator_uuid_map(txids):
     return {compute_locator(txid): uuid4().hex for txid in txids}
 
 
+# FIXME: 194 will do with dummy appointment
 def create_appointments(generate_dummy_appointment, n):
     locator_uuid_map = dict()
     appointments = dict()
@@ -317,6 +318,7 @@ def test_watcher_init(watcher):
     assert isinstance(watcher.locator_cache, LocatorCache)
 
 
+# FIXME: 194 will do with dummy appointment
 def test_add_appointment_non_registered(watcher, generate_dummy_appointment):
     # Appointments from non-registered users should fail
     user_sk, user_pk = generate_keypair()
@@ -328,6 +330,7 @@ def test_add_appointment_non_registered(watcher, generate_dummy_appointment):
         watcher.add_appointment(appointment, appointment_signature)
 
 
+# FIXME: 194 will do with dummy appointment
 def test_add_appointment_no_slots(watcher, generate_dummy_appointment):
     # Appointments from register users with no available slots should aso fail
     user_sk, user_pk = generate_keypair()
@@ -341,6 +344,7 @@ def test_add_appointment_no_slots(watcher, generate_dummy_appointment):
         watcher.add_appointment(appointment, appointment_signature)
 
 
+# FIXME: 194 will do with dummy appointment
 def test_add_appointment(watcher, generate_dummy_appointment):
     # Simulate the user is registered
     user_sk, user_pk = generate_keypair()
@@ -429,6 +433,7 @@ def test_add_appointment_in_cache(watcher, generate_dummy_appointment):
         watcher.add_appointment(appointment, Cryptographer.sign(appointment.serialize(), user_sk))
 
 
+# FIXME: 194 will do with dummy appointment
 def test_add_appointment_in_cache_invalid_blob(watcher):
     # Generate an appointment with an invalid transaction and add the dispute txid to the cache
     user_sk, user_pk = generate_keypair()
@@ -497,6 +502,7 @@ def test_add_appointment_in_cache_invalid_transaction(watcher, generate_dummy_ap
     assert appointment.locator not in [tracker.get("locator") for tracker in watcher.responder.trackers.values()]
 
 
+# FIXME: 194 will do with dummy appointment
 def test_add_too_many_appointments(watcher, generate_dummy_appointment):
     # Simulate the user is registered
     user_sk, user_pk = generate_keypair()
@@ -601,6 +607,7 @@ def test_do_watch_cache_update(watcher):
         assert len(watcher.locator_cache.blocks) == watcher.locator_cache.cache_size
 
 
+# FIXME: 194 will do with dummy watcher
 def test_get_breaches(watcher, txids, locator_uuid_map):
     watcher.locator_uuid_map = locator_uuid_map
     locators_txid_map = {compute_locator(txid): txid for txid in txids}
@@ -610,6 +617,7 @@ def test_get_breaches(watcher, txids, locator_uuid_map):
     assert locator_uuid_map.keys() == potential_breaches.keys()
 
 
+# FIXME: 194 will do with dummy watcher
 def test_get_breaches_random_data(watcher, locator_uuid_map):
     # The likelihood of finding a potential breach with random data should be negligible
     watcher.locator_uuid_map = locator_uuid_map
@@ -622,6 +630,7 @@ def test_get_breaches_random_data(watcher, locator_uuid_map):
     assert len(potential_breaches) == 0
 
 
+# FIXME: 194 will do with dummy watcher and appointment
 def test_check_breach(watcher, generate_dummy_appointment):
     # A breach will be flagged as valid only if the encrypted blob can be properly decrypted and the resulting data
     # matches a transaction format.
@@ -633,6 +642,7 @@ def test_check_breach(watcher, generate_dummy_appointment):
     assert Cryptographer.encrypt(penalty_rawtx, dispute_txid) == appointment.encrypted_blob
 
 
+# FIXME: 194 will do with dummy watcher and appointment
 def test_check_breach_random_data(watcher, generate_dummy_appointment):
     # If a breach triggers an appointment with random data as encrypted blob, the check should fail.
     uuid = uuid4().hex
@@ -646,6 +656,7 @@ def test_check_breach_random_data(watcher, generate_dummy_appointment):
         watcher.check_breach(uuid, appointment, dispute_txid)
 
 
+# FIXME: 194 will do with dummy watcher and appointment
 def test_check_breach_invalid_transaction(watcher, generate_dummy_appointment):
     # If the breach triggers an appointment with data that can be decrypted but does not match a transaction, it should
     # fail
@@ -660,6 +671,7 @@ def test_check_breach_invalid_transaction(watcher, generate_dummy_appointment):
         watcher.check_breach(uuid, appointment, dispute_txid)
 
 
+# FIXME: 194 will do with dummy watcher
 def test_filter_valid_breaches(watcher, generate_dummy_appointment):
     dispute_txid = "0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9"
     encrypted_blob = (
@@ -693,6 +705,7 @@ def test_filter_valid_breaches(watcher, generate_dummy_appointment):
     assert len(invalid_breaches) == 0 and len(valid_breaches) == 1
 
 
+# FIXME: 194 will do with dummy watcher and appointment
 def test_filter_breaches_random_data(watcher, generate_dummy_appointment):
     appointments = {}
     locator_uuid_map = {}


### PR DESCRIPTION
Make the dependency to the run_bitcoind fixture explicit in tests that need it, so that unit tests can be ran individually.

This PR only takes care of the unit tests, not the e2e tests.

After that, 6 tests needed fixing as they functionally depended on the side effects of previous tests in the same test module:
- `test_get_appointment_in_watcher` and `test_get_appointment_in_responder` in test_api.py
- `test_delete_locator_map`, `test_delete_watcher_appointment` and `test_delete_responder_tracker` in test_appointments_dbm.py
- `test_do_watch_cache_update` in test_watcher.py

Fixed all of the above, except `test_do_watch_cache_update`: that is basically an integration test (together with the previous test, `test_do_watch`), so it might perhaps be better refactored out of the unit tests suite, but that is out of scope for this ticket. Left a TODO there.
 
Closes: #166 