### PR TITLE
Fixes grpc with multiprocess

### DIFF
--- a/teos/internal_api.py
+++ b/teos/internal_api.py
@@ -46,6 +46,26 @@ class InternalAPI:
         add_TowerServicesServicer_to_server(_InternalAPI(watcher, self.logger), self.rpc_server)
 
 
+def serve(watcher, internal_api_endpoint):
+    """
+    Serves the internal API at a given endpoint.
+
+    This method will serve and hold until the main process is started or a stop signal is received. Notice the later is
+    not possible possible currently since the stop signal has to be passed to `rpc_server` and it is not returned. This
+    may change once the stop command for the CLI is implemented.
+
+    Args:
+        watcher (:obj:`Watcher <teos.watcher.Watcher`): The ``Watcher`` instance (backend).
+        internal_api_endpoint (:obj:`str`): the endpoint where to reach the internal (gRPC) api.
+    """
+
+    internal_api = InternalAPI(watcher, internal_api_endpoint)
+    internal_api.rpc_server.start()
+
+    internal_api.logger.info(f"Initialized. Serving at {internal_api.endpoint}")
+    internal_api.rpc_server.wait_for_termination()
+
+
 class _InternalAPI(TowerServicesServicer):
     """
     This represents the internal api service provider and implements all the gRPC methods offered by the API.

--- a/teos/internal_api.py
+++ b/teos/internal_api.py
@@ -50,7 +50,7 @@ def serve(watcher, internal_api_endpoint):
     """
     Serves the internal API at a given endpoint.
 
-    This method will serve and hold until the main process is started or a stop signal is received. Notice the later is
+    This method will serve and hold until the main process is stop or a stop signal is received. Notice the latter is
     not possible possible currently since the stop signal has to be passed to `rpc_server` and it is not returned. This
     may change once the stop command for the CLI is implemented.
 

--- a/teos/rpc.py
+++ b/teos/rpc.py
@@ -58,7 +58,7 @@ def serve(rpc_bind, rpc_port, internal_api_endpoint):
     """
     Serves the external RPC API at the given endpoint and connects it to the internal api.
 
-    This method will serve and hold until the main process is started or a stop signal is received. Notice the later is
+    This method will serve and hold until the main process is stop or a stop signal is received. Notice the latter is
     not possible possible currently since the stop signal has to be passed to `rpc_server` and it is not returned. This
     may change once the stop command for the CLI is implemented.
 


### PR DESCRIPTION
Turns out gRPC in Python has some issues when using multiprocess. A way or working around it is to create the processes (fork) before instantiating anything related to gRPC.

This PR modifies the `InternalAPI` to be run in a similar way as the `RPC` does. Then the former is run in the main process but after the latter has been forked into a different process.

How the processes are handled have not changed from before (the main process takes care of the backend while the forked process takes care of the external RPC server).

Some info and related issues:

https://github.com/grpc/grpc/tree/b8241addc380e63b28be850c3da2fb04dc75212b/examples/python/multiprocessing

https://github.com/grpc/grpc/blob/master/doc/fork_support.md

https://github.com/grpc/grpc/issues/16001