### PR TITLE
Add a "stop" command for graceful shutdown

### DIFF
--- a/teos/api.py
+++ b/teos/api.py
@@ -75,10 +75,7 @@ def serve(internal_api_endpoint, endpoint, min_to_self_delay, log_file, auto_run
         The application object needed by the WSGI server to run if ``auto_run`` if ``False``, ``None`` otherwise.
     """
 
-    # For Python 3.7- and 3.8+ compatibility. Processes for MacOS are created as fork up to 3.8 by default, then it got
-    # changed to spawn.
-    if mpp.get_start_method() == "spawn":
-        setup_logging(log_file)
+    setup_logging(log_file)
     inspector = Inspector(int(min_to_self_delay))
     api = API(inspector, internal_api_endpoint)
 

--- a/teos/cli/help.py
+++ b/teos/cli/help.py
@@ -58,3 +58,14 @@ def help_get_user():
         "\n\nDESCRIPTION:"
         "\n\n\tGets information about a specific user.\n"
     )
+
+
+def help_stop():
+    return (
+        "NAME:"
+        "\tpython teos_cli stop - Requests a graceful shutdown of the tower."
+        "\n\nUSAGE:"
+        "\tpython teos_cli.py stop"
+        "\n\nDESCRIPTION:"
+        "\n\n\Requests a graceful shutdown of the tower.\n"
+    )

--- a/teos/cli/help.py
+++ b/teos/cli/help.py
@@ -67,5 +67,5 @@ def help_stop():
         "\n\nUSAGE:"
         "\tpython teos_cli.py stop"
         "\n\nDESCRIPTION:"
-        "\n\n\Requests a graceful shutdown of the tower.\n"
+        "\n\n\tRequests a graceful shutdown of the tower.\n"
     )

--- a/teos/cli/teos_cli.py
+++ b/teos/cli/teos_cli.py
@@ -104,8 +104,9 @@ class RPCClient:
         return result.user
 
     def stop(self):
+        """Stops TEOS gracefully."""
         self.stub.stop(Empty())
-        return "Closing the Eye of Satoshi"
+        print("Closing the Eye of Satoshi")
 
 
 def main(command, args, command_line_conf):

--- a/teos/cli/teos_cli.py
+++ b/teos/cli/teos_cli.py
@@ -14,7 +14,14 @@ from common.tools import setup_data_folder, is_compressed_pk, intify
 from common.exceptions import InvalidParameter
 
 from teos import DEFAULT_CONF, DATA_DIR, CONF_FILE_NAME
-from teos.cli.help import show_usage, help_get_all_appointments, help_get_tower_info, help_get_users, help_get_user
+from teos.cli.help import (
+    show_usage,
+    help_get_all_appointments,
+    help_get_tower_info,
+    help_get_users,
+    help_get_user,
+    help_stop,
+)
 from teos.protobuf.tower_services_pb2_grpc import TowerServicesStub
 from teos.protobuf.user_pb2 import GetUserRequest
 
@@ -96,6 +103,10 @@ class RPCClient:
         result = self.stub.get_user(GetUserRequest(user_id=user_id))
         return result.user
 
+    def stop(self):
+        self.stub.stop(Empty())
+        return "Closing the Eye of Satoshi"
+
 
 def main(command, args, command_line_conf):
     # Loads config and sets up the data folder and log file
@@ -126,6 +137,10 @@ def main(command, args, command_line_conf):
                 sys.exit(f"Expected only one argument, not {len(args)}")
 
             result = rpc_client.get_user(args[0])
+
+        elif command == "stop":
+            result = rpc_client.stop()
+
         elif command == "help":
             if args:
                 command = args.pop(0)
@@ -141,6 +156,9 @@ def main(command, args, command_line_conf):
 
                 elif command == "get_user":
                     sys.exit(help_get_user())
+
+                elif command == "stop":
+                    sys.exit(help_stop())
 
                 else:
                     sys.exit("Unknown command. Use help to check the list of available commands")
@@ -164,7 +182,7 @@ def main(command, args, command_line_conf):
 
 if __name__ == "__main__":
     command_line_conf = {}
-    commands = ["get_all_appointments", "get_appointments", "get_tower_info", "get_users", "get_user", "help"]
+    commands = ["get_all_appointments", "get_appointments", "get_tower_info", "get_users", "get_user", "stop", "help"]
 
     try:
         opts, args = getopt(argv[1:], "h", ["rpcbind=", "rpcport=", "help"])

--- a/teos/cli/teos_cli.py
+++ b/teos/cli/teos_cli.py
@@ -121,6 +121,7 @@ def main(command, args, command_line_conf):
 
     rpc_client = RPCClient(teos_rpc_host, teos_rpc_port)
 
+    result = None
     try:
         if command == "get_all_appointments":
             result = rpc_client.get_all_appointments()
@@ -137,7 +138,7 @@ def main(command, args, command_line_conf):
             if len(args) > 1:
                 sys.exit(f"Expected only one argument, not {len(args)}")
 
-            result = rpc_client.get_user(args[0])
+            rpc_client.get_user(args[0])
 
         elif command == "stop":
             result = rpc_client.stop()

--- a/teos/constants.py
+++ b/teos/constants.py
@@ -1,0 +1,6 @@
+INTERNAL_API_HOST = "localhost"
+INTERNAL_API_PORT = "50051"
+INTERNAL_API_ENDPOINT = f"{INTERNAL_API_HOST}:{INTERNAL_API_PORT}"
+
+# the grace time in seconds to complete any pending call when stopping one of the services of TEOS
+SHUTDOWN_GRACE_TIME = 10

--- a/teos/internal_api.py
+++ b/teos/internal_api.py
@@ -44,6 +44,7 @@ class InternalAPI:
         self.logger = get_logger(component=InternalAPI.__name__)
         self.watcher = watcher
         self.endpoint = internal_api_endpoint
+        self.stop_command_event = stop_command_event
         self.rpc_server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
         self.rpc_server.add_insecure_port(self.endpoint)
         add_TowerServicesServicer_to_server(_InternalAPI(watcher, stop_command_event, self.logger), self.rpc_server)

--- a/teos/internal_api.py
+++ b/teos/internal_api.py
@@ -191,5 +191,6 @@ class _InternalAPI(TowerServicesServicer):
             return GetUserResponse(user=user_struct)
 
     def stop(self, request, context):
+        """Initiates a graceful shutdown of the tower."""
         self.stop_command_event.set()
         return Empty()

--- a/teos/protobuf/protos/tower_services.proto
+++ b/teos/protobuf/protos/tower_services.proto
@@ -23,4 +23,5 @@ service TowerServices {
   rpc get_tower_info(google.protobuf.Empty) returns (GetTowerInfoResponse) {}
   rpc get_users(google.protobuf.Empty) returns (GetUsersResponse) {}
   rpc get_user(GetUserRequest) returns (GetUserResponse) {}
+  rpc stop(google.protobuf.Empty) returns (google.protobuf.Empty) {}
 }

--- a/teos/protobuf/tower_services_pb2.py
+++ b/teos/protobuf/tower_services_pb2.py
@@ -23,8 +23,8 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     syntax="proto3",
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
-    serialized_pb=b'\n\x14tower_services.proto\x12\x17teos.protobuf.protos.v1\x1a\x11\x61ppointment.proto\x1a\nuser.proto\x1a\x1bgoogle/protobuf/empty.proto"\x82\x01\n\x14GetTowerInfoResponse\x12\x1e\n\x16n_watcher_appointments\x18\x01 \x01(\r\x12\x1c\n\x14n_responder_trackers\x18\x02 \x01(\r\x12\x1a\n\x12n_registered_users\x18\x03 \x01(\r\x12\x10\n\x08tower_id\x18\x04 \x01(\t2\xd3\x05\n\rTowerServices\x12\x61\n\x08register\x12(.teos.protobuf.protos.v1.RegisterRequest\x1a).teos.protobuf.protos.v1.RegisterResponse"\x00\x12t\n\x0f\x61\x64\x64_appointment\x12..teos.protobuf.protos.v1.AddAppointmentRequest\x1a/.teos.protobuf.protos.v1.AddAppointmentResponse"\x00\x12t\n\x0fget_appointment\x12..teos.protobuf.protos.v1.GetAppointmentRequest\x1a/.teos.protobuf.protos.v1.GetAppointmentResponse"\x00\x12\x65\n\x14get_all_appointments\x12\x16.google.protobuf.Empty\x1a\x33.teos.protobuf.protos.v1.GetAllAppointmentsResponse"\x00\x12Y\n\x0eget_tower_info\x12\x16.google.protobuf.Empty\x1a-.teos.protobuf.protos.v1.GetTowerInfoResponse"\x00\x12P\n\tget_users\x12\x16.google.protobuf.Empty\x1a).teos.protobuf.protos.v1.GetUsersResponse"\x00\x12_\n\x08get_user\x12\'.teos.protobuf.protos.v1.GetUserRequest\x1a(.teos.protobuf.protos.v1.GetUserResponse"\x00\x62\x06proto3',
-    dependencies=[appointment__pb2.DESCRIPTOR, user__pb2.DESCRIPTOR, google_dot_protobuf_dot_empty__pb2.DESCRIPTOR],
+    serialized_pb=b'\n\x14tower_services.proto\x12\x17teos.protobuf.protos.v1\x1a\x11\x61ppointment.proto\x1a\nuser.proto\x1a\x1bgoogle/protobuf/empty.proto"\x82\x01\n\x14GetTowerInfoResponse\x12\x1e\n\x16n_watcher_appointments\x18\x01 \x01(\r\x12\x1c\n\x14n_responder_trackers\x18\x02 \x01(\r\x12\x1a\n\x12n_registered_users\x18\x03 \x01(\r\x12\x10\n\x08tower_id\x18\x04 \x01(\t2\x8d\x06\n\rTowerServices\x12\x61\n\x08register\x12(.teos.protobuf.protos.v1.RegisterRequest\x1a).teos.protobuf.protos.v1.RegisterResponse"\x00\x12t\n\x0f\x61\x64\x64_appointment\x12..teos.protobuf.protos.v1.AddAppointmentRequest\x1a/.teos.protobuf.protos.v1.AddAppointmentResponse"\x00\x12t\n\x0fget_appointment\x12..teos.protobuf.protos.v1.GetAppointmentRequest\x1a/.teos.protobuf.protos.v1.GetAppointmentResponse"\x00\x12\x65\n\x14get_all_appointments\x12\x16.google.protobuf.Empty\x1a\x33.teos.protobuf.protos.v1.GetAllAppointmentsResponse"\x00\x12Y\n\x0eget_tower_info\x12\x16.google.protobuf.Empty\x1a-.teos.protobuf.protos.v1.GetTowerInfoResponse"\x00\x12P\n\tget_users\x12\x16.google.protobuf.Empty\x1a).teos.protobuf.protos.v1.GetUsersResponse"\x00\x12_\n\x08get_user\x12\'.teos.protobuf.protos.v1.GetUserRequest\x1a(.teos.protobuf.protos.v1.GetUserResponse"\x00\x12\x38\n\x04stop\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.Empty"\x00\x62\x06proto3',
+    dependencies=[appointment__pb2.DESCRIPTOR, user__pb2.DESCRIPTOR, google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,],
 )
 
 
@@ -148,7 +148,7 @@ _TOWERSERVICES = _descriptor.ServiceDescriptor(
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
     serialized_start=243,
-    serialized_end=966,
+    serialized_end=1024,
     methods=[
         _descriptor.MethodDescriptor(
             name="register",
@@ -217,6 +217,16 @@ _TOWERSERVICES = _descriptor.ServiceDescriptor(
             containing_service=None,
             input_type=user__pb2._GETUSERREQUEST,
             output_type=user__pb2._GETUSERRESPONSE,
+            serialized_options=None,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.MethodDescriptor(
+            name="stop",
+            full_name="teos.protobuf.protos.v1.TowerServices.stop",
+            index=7,
+            containing_service=None,
+            input_type=google_dot_protobuf_dot_empty__pb2._EMPTY,
+            output_type=google_dot_protobuf_dot_empty__pb2._EMPTY,
             serialized_options=None,
             create_key=_descriptor._internal_create_key,
         ),

--- a/teos/protobuf/tower_services_pb2_grpc.py
+++ b/teos/protobuf/tower_services_pb2_grpc.py
@@ -52,6 +52,11 @@ class TowerServicesStub(object):
             request_serializer=user__pb2.GetUserRequest.SerializeToString,
             response_deserializer=user__pb2.GetUserResponse.FromString,
         )
+        self.stop = channel.unary_unary(
+            "/teos.protobuf.protos.v1.TowerServices/stop",
+            request_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+            response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+        )
 
 
 class TowerServicesServicer(object):
@@ -99,6 +104,12 @@ class TowerServicesServicer(object):
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
+    def stop(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details("Method not implemented!")
+        raise NotImplementedError("Method not implemented!")
+
 
 def add_TowerServicesServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -136,6 +147,11 @@ def add_TowerServicesServicer_to_server(servicer, server):
             servicer.get_user,
             request_deserializer=user__pb2.GetUserRequest.FromString,
             response_serializer=user__pb2.GetUserResponse.SerializeToString,
+        ),
+        "stop": grpc.unary_unary_rpc_method_handler(
+            servicer.stop,
+            request_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+            response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
         ),
     }
     generic_handler = grpc.method_handlers_generic_handler("teos.protobuf.protos.v1.TowerServices", rpc_method_handlers)
@@ -334,3 +350,31 @@ class TowerServices(object):
             timeout,
             metadata,
         )
+
+    @staticmethod
+    def stop(
+        request,
+        target,
+        options=(),
+        channel_credentials=None,
+        call_credentials=None,
+        compression=None,
+        wait_for_ready=None,
+        timeout=None,
+        metadata=None,
+    ):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            "/teos.protobuf.protos.v1.TowerServices/stop",
+            google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+            google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+            options,
+            channel_credentials,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+        )
+

--- a/teos/protobuf/tower_services_pb2_grpc.py
+++ b/teos/protobuf/tower_services_pb2_grpc.py
@@ -377,4 +377,3 @@ class TowerServices(object):
             timeout,
             metadata,
         )
-

--- a/teos/rpc.py
+++ b/teos/rpc.py
@@ -4,14 +4,12 @@ from concurrent import futures
 
 from common.logger import get_logger
 
+from teos.constants import SHUTDOWN_GRACE_TIME
 from teos.protobuf.tower_services_pb2_grpc import (
     TowerServicesStub,
     TowerServicesServicer,
     add_TowerServicesServicer_to_server,
 )
-
-# the grace time in seconds to complete any pending rpc call when a `stop` command is received
-SHUTDOWN_GRACE_TIME = 10
 
 
 class RPC:
@@ -41,8 +39,8 @@ class RPC:
 
 def forward_errors(func):
     """
-    Transforms `func` in order to forward any grpc.RPCError returned by the upstream grpc as the result of the current
-    grpc call.
+    Transforms ``func`` in order to forward any ``grpc.RPCError`` returned by the upstream grpc as the result of the
+    current grpc call.
     """
 
     @functools.wraps(func)
@@ -104,7 +102,8 @@ def serve(rpc_bind, rpc_port, internal_api_endpoint, stop_event):
         rpc_bind (:obj:`str`): the IP or host where the RPC server will be hosted.
         rpc_port (:obj:`int`): the port where the RPC server will be hosted.
         internal_api_endpoint (:obj:`str`): the endpoint where to reach the internal (gRPC) api.
-        stop_event TODO
+        stop_event (:obj:`multiprocessing.Event`) the Event that this service will monitor. The rpc server will
+            initiate a graceful shutdown once this event is set.
     """
 
     rpc = RPC(rpc_bind, rpc_port, internal_api_endpoint)

--- a/teos/rpc.py
+++ b/teos/rpc.py
@@ -108,10 +108,7 @@ def serve(rpc_bind, rpc_port, internal_api_endpoint, stop_event, log_file):
             initiate a graceful shutdown once this event is set.
     """
 
-    # For Python 3.7- and 3.8+ compatibility. Processes for MacOS are created as fork up to 3.8 by default, then it got
-    # changed to spawn.
-    if mpp.get_start_method() == "spawn":
-        setup_logging(log_file)
+    setup_logging(log_file)
     rpc = RPC(rpc_bind, rpc_port, internal_api_endpoint)
     rpc.rpc_server.start()
 

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -138,7 +138,7 @@ class TeosDaemon:
             self.config.get("LOCATOR_CACHE_SIZE"),
         )
 
-        # Create the chain monitor and start monitoring the chain
+        # Create the chain monitor
         self.chain_monitor = ChainMonitor(
             self.watcher.block_queue, self.watcher.responder.block_queue, self.block_processor, bitcoind_feed_params
         )
@@ -166,15 +166,20 @@ class TeosDaemon:
     def start(self):
         """This method implements the whole lifetime cycle of the the TEOS tower. This method does not return."""
         logger.info("Starting TEOS")
-        self.setup_components()
+        self.bootstrap_components()
         self.start_services()
 
         self.stop_command_event.wait()
 
         self.teardown()
 
-    def setup_components(self):
-        """Performs the initial setup and creates all the components."""
+    def bootstrap_components(self):
+        """
+        Performs the initial setup of the components. It loads the appointments and tracker for the watcher and the
+        responder (if any), and awakes the components. It also populates the block queues with any missing data, in
+        case the tower has been offline for some time. Finally, it starts the chain monitor.
+        """
+
         watcher_appointments_data = self.db_manager.load_watcher_appointments()
         responder_trackers_data = self.db_manager.load_responder_trackers()
 

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -342,6 +342,10 @@ def main(config):
 
 
 if __name__ == "__main__":
+    # Subprocess need to be run using "spawn" for consistent execution between different OS. No state is really shared
+    # between process.
+    multiprocessing.set_start_method("spawn")
+
     command_line_conf = {}
     data_dir = DATA_DIR
 

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -142,16 +142,6 @@ class TeosDaemon:
         # It will be an instance of either Popen or Process, depending on the WSGI config setting.
         self.api_proc = None
 
-    def start(self):
-        """This method implements the whole lifetime cycle of the the TEOS tower. This method does not return."""
-        logger.info("Starting TEOS")
-        self.bootstrap_components()
-        self.start_services()
-
-        self.stop_command_event.wait()
-
-        self.teardown()
-
     def bootstrap_components(self):
         """
         Performs the initial setup of the components. It loads the appointments and tracker for the watcher and the
@@ -269,7 +259,7 @@ class TeosDaemon:
 
     def handle_signals(self, signum, frame):
         """Handles signals by initiating a graceful shutdown."""
-        logger.info(f"Signal {signum} received. Stopping")
+        logger.debug(f"Signal {signum} received. Stopping")
 
         self.stop_command_event.set()
 
@@ -312,6 +302,16 @@ class TeosDaemon:
 
         logger.info("Shutting down TEOS")
         exit(0)
+
+    def start(self):
+        """This method implements the whole lifetime cycle of the the TEOS tower. This method does not return."""
+        logger.info("Starting TEOS")
+        self.bootstrap_components()
+        self.start_services()
+
+        self.stop_command_event.wait()
+
+        self.teardown()
 
 
 def main(config):

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -150,7 +150,13 @@ class TeosDaemon:
         # Create the rpc, without starting it
         self.rpc_process = multiprocessing.Process(
             target=rpc.serve,
-            args=(self.config.get("RPC_BIND"), self.config.get("RPC_PORT"), INTERNAL_API_ENDPOINT, self.stop_event),
+            args=(
+                self.config.get("RPC_BIND"),
+                self.config.get("RPC_PORT"),
+                INTERNAL_API_ENDPOINT,
+                self.stop_event,
+                self.config.get("LOG_FILE"),
+            ),
             daemon=True,
         )
 

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -248,12 +248,14 @@ class TeosDaemon:
         signal(SIGTERM, self.handle_signals)
         signal(SIGQUIT, self.handle_signals)
 
-        # Start the internal API
-        self.internal_api.rpc_server.start()
-        logger.info(f"Internal API initialized. Serving at {INTERNAL_API_ENDPOINT}")
-
         # Start the rpc process
         self.rpc_process.start()
+
+        # Start the internal API
+        # This MUST be done after rpc_process.start to avoid the issue that was solved in
+        # https://github.com/talaia-labs/python-teos/pull/198
+        self.internal_api.rpc_server.start()
+        logger.info(f"Internal API initialized. Serving at {INTERNAL_API_ENDPOINT}")
 
         # Start the public API server
         api_endpoint = f"{self.config.get('API_BIND')}:{self.config.get('API_PORT')}"

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -293,6 +293,9 @@ class TeosDaemon:
             self.api_popen.terminate()
             self.api_popen.wait()
         else:
+            # FIXME: when the public API process is ran with flask, there is no SIGTERM handler attempting
+            # a graceful shutdown (rejecting new requests, trying to complete ongoing ones); therefore, we send
+            # a SIGKILL instead.
             self.api_process.kill()
             self.api_process.join()
 
@@ -303,7 +306,6 @@ class TeosDaemon:
 
         # wait for RPC process to shutdown
         self.rpc_process.join()
-        # TODO: should we have a timeout on rpc_process.join()? Should we kill the process on timeout?
 
         # Stops the internal API, after waiting for some grace time
         logger.info("Internal API stopping")

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -28,15 +28,10 @@ from teos.block_processor import BlockProcessor
 from teos.appointments_dbm import AppointmentsDBM
 from teos import DATA_DIR, DEFAULT_CONF, CONF_FILE_NAME
 from teos.tools import can_connect_to_bitcoind, in_correct_network, get_default_rpc_port
+from teos.constants import INTERNAL_API_ENDPOINT, SHUTDOWN_GRACE_TIME
 
 logger = get_logger(component="Daemon")
 parent_pid = os.getpid()
-
-INTERNAL_API_HOST = "localhost"
-INTERNAL_API_PORT = "50051"
-INTERNAL_API_ENDPOINT = f"{INTERNAL_API_HOST}:{INTERNAL_API_PORT}"
-# the grace time in seconds to complete any pending internal api call when stopping teosd
-INTERNAL_API_SHUTDOWN_GRACE_TIME = 10
 
 
 def get_config(command_line_conf, data_dir):
@@ -63,20 +58,23 @@ def get_config(command_line_conf, data_dir):
 
 class TeosDaemon:
     """
-    The :class:`TeosDaemon` organizes the code to initialize all the components of teos, start the service, stop and teardown.
+    The :class:`TeosDaemon` organizes the code to initialize all the components of teos, start the service, stop and
+    teardown.
 
     Args:
         config (:obj:`dict`): the configuration object.
 
     Attributes:
-        stop_command_event (:obj"`threading.Event`) the Event that will be set to initiate a graceful shutdown.
-        stop_event (:obj"`multiprocessing.Event`) the Event that services running on different processes will monitor
+        stop_command_event (:obj:`threading.Event`) the Event that will be set to initiate a graceful shutdown.
+        stop_event (:obj:`multiprocessing.Event`) the Event that services running on different processes will monitor
             in order to be informed that they should shutdown.
+        block_processor (:obj:`teos.block_processor.BlockProcessor`) the BlockProcessor instance.
         db_manager (:obj:`teos.appointments_dbm.AppointmentsDBM`) the db manager for appointments.
         watcher (:obj:`teos.watcher.Watcher`) the `Watcher` instance.
-        chain_monitor (:obj:`teos.chain_monitor.ChainMonitor`) the `ChainMonitor` instance.
-        self.api_popen (:obj:`subprocess.Popen` or "obj"`None`) if set, the `Popen` instance running the public API.
-        self.api_process (:obj:`multiprocessing.Process` or "obj"`None`) if set, the `Process` instance running the public API.
+        chain_monitor (:obj:`teos.chain_monitor.ChainMonitor`) the ``ChainMonitor`` instance.
+        self.api_popen (:obj:`subprocess.Popen` or :obj:`None`) if set, the ``Popen`` instance running the public API.
+        self.api_process (:obj:`multiprocessing.Process` or :obj:`None`) if set, the ``Process`` instance running the
+            public API.
         self.rpc_process (:obj:`multiprocessing.Process`) the instance of the internal RPC server; only set if running.
         self.internal_api (:obj:`teos.internal_api.InternalAPI`) the InternalAPI instance.
     """
@@ -84,7 +82,7 @@ class TeosDaemon:
     def __init__(self, config):
         self.config = config
 
-        # event triggered when a `stop` command is issued
+        # event triggered when a ``stop`` command is issued
         # Using multiprocessing.Event seems to cause a deadlock if event.set() is called in a signal handler that
         # interrupted event.wait(). This does not happen with threading.Event.
         # See https://bugs.python.org/issue41606
@@ -93,23 +91,6 @@ class TeosDaemon:
         # event triggered when the public API is halted, hence teosd is ready to stop
         self.stop_event = multiprocessing.Event()
 
-    def start(self):
-        """This method implements the whole lifetime cycle of the the TEOS tower. This method does not return."""
-        try:
-            logger.info("Starting TEOS")
-            self.setup_components()
-            self.start_services()
-
-            self.stop_command_event.wait()
-
-            self.teardown()
-
-        except Exception as e:
-            logger.error("An error occurred: {}. Shutting down".format(e))
-            exit(1)
-
-    def setup_components(self):
-        """Performs the initial setup and creates all the components."""
         setup_data_folder(self.config.get("DATA_DIR"))
         setup_logging(self.config.get("LOG_FILE"))
 
@@ -117,119 +98,144 @@ class TeosDaemon:
         bitcoind_feed_params = {k: v for k, v in self.config.items() if k.startswith("BTC_FEED")}
 
         if not can_connect_to_bitcoind(bitcoind_connect_params):
-            logger.error("Cannot connect to bitcoind. Shutting down")
+            raise RuntimeError("Cannot connect to bitcoind")
 
         elif not in_correct_network(bitcoind_connect_params, self.config.get("BTC_NETWORK")):
-            logger.error("bitcoind is running on a different network, check teos.conf and bitcoin.conf. Shutting down")
+            raise RuntimeError("bitcoind is running on a different network, check teos.conf and bitcoin.conf")
+
+        if not os.path.exists(self.config.get("TEOS_SECRET_KEY")) or self.config.get("OVERWRITE_KEY"):
+            logger.info("Generating a new key pair")
+            sk = Cryptographer.generate_key()
+            Cryptographer.save_key_file(sk.to_der(), "teos_sk", self.config.get("DATA_DIR"))
 
         else:
-            if not os.path.exists(self.config.get("TEOS_SECRET_KEY")) or self.config.get("OVERWRITE_KEY"):
-                logger.info("Generating a new key pair")
-                sk = Cryptographer.generate_key()
-                Cryptographer.save_key_file(sk.to_der(), "teos_sk", self.config.get("DATA_DIR"))
+            logger.info("Tower identity found. Loading keys")
+            secret_key_der = Cryptographer.load_key_file(self.config.get("TEOS_SECRET_KEY"))
 
-            else:
-                logger.info("Tower identity found. Loading keys")
-                secret_key_der = Cryptographer.load_key_file(self.config.get("TEOS_SECRET_KEY"))
+            if not secret_key_der:
+                raise IOError("TEOS private key cannot be loaded")
+            sk = Cryptographer.load_private_key_der(secret_key_der)
 
-                if not secret_key_der:
-                    raise IOError("TEOS private key cannot be loaded")
-                sk = Cryptographer.load_private_key_der(secret_key_der)
+        logger.info("tower_id = {}".format(Cryptographer.get_compressed_pk(sk.public_key)))
+        self.block_processor = BlockProcessor(bitcoind_connect_params)
+        carrier = Carrier(bitcoind_connect_params)
 
-            logger.info("tower_id = {}".format(Cryptographer.get_compressed_pk(sk.public_key)))
-            block_processor = BlockProcessor(bitcoind_connect_params)
-            carrier = Carrier(bitcoind_connect_params)
+        gatekeeper = Gatekeeper(
+            UsersDBM(self.config.get("USERS_DB_PATH")),
+            self.block_processor,
+            self.config.get("SUBSCRIPTION_SLOTS"),
+            self.config.get("SUBSCRIPTION_DURATION"),
+            self.config.get("EXPIRY_DELTA"),
+        )
+        self.db_manager = AppointmentsDBM(self.config.get("APPOINTMENTS_DB_PATH"))
+        responder = Responder(self.db_manager, gatekeeper, carrier, self.block_processor)
+        self.watcher = Watcher(
+            self.db_manager,
+            gatekeeper,
+            self.block_processor,
+            responder,
+            sk,
+            self.config.get("MAX_APPOINTMENTS"),
+            self.config.get("LOCATOR_CACHE_SIZE"),
+        )
 
-            gatekeeper = Gatekeeper(
-                UsersDBM(self.config.get("USERS_DB_PATH")),
-                block_processor,
-                self.config.get("SUBSCRIPTION_SLOTS"),
-                self.config.get("SUBSCRIPTION_DURATION"),
-                self.config.get("EXPIRY_DELTA"),
-            )
-            self.db_manager = AppointmentsDBM(self.config.get("APPOINTMENTS_DB_PATH"))
-            responder = Responder(self.db_manager, gatekeeper, carrier, block_processor)
-            self.watcher = Watcher(
-                self.db_manager,
-                gatekeeper,
-                block_processor,
-                responder,
-                sk,
-                self.config.get("MAX_APPOINTMENTS"),
-                self.config.get("LOCATOR_CACHE_SIZE"),
-            )
+        # Create the chain monitor and start monitoring the chain
+        self.chain_monitor = ChainMonitor(
+            self.watcher.block_queue, self.watcher.responder.block_queue, self.block_processor, bitcoind_feed_params
+        )
 
-            # Create the chain monitor and start monitoring the chain
-            self.chain_monitor = ChainMonitor(
-                self.watcher.block_queue, self.watcher.responder.block_queue, block_processor, bitcoind_feed_params
-            )
+        # Set up the internal API
+        self.internal_api = InternalAPI(self.watcher, INTERNAL_API_ENDPOINT, self.stop_command_event)
 
-            watcher_appointments_data = self.db_manager.load_watcher_appointments()
-            responder_trackers_data = self.db_manager.load_responder_trackers()
+        # Create the rpc, without starting it
+        self.rpc_process = multiprocessing.Process(
+            target=rpc.serve,
+            args=(self.config.get("RPC_BIND"), self.config.get("RPC_PORT"), INTERNAL_API_ENDPOINT, self.stop_event),
+            daemon=True,
+        )
 
-            if len(watcher_appointments_data) == 0 and len(responder_trackers_data) == 0:
-                logger.info("Fresh bootstrap")
+        # One of this variables will contain the handle of the process running the API, when the service is started
+        self.api_popen = None
+        self.api_process = None
 
-                self.watcher.awake()
-                self.watcher.responder.awake()
+    def start(self):
+        """This method implements the whole lifetime cycle of the the TEOS tower. This method does not return."""
+        logger.info("Starting TEOS")
+        self.setup_components()
+        self.start_services()
 
-            else:
-                logger.info("Bootstrapping from backed up data")
+        self.stop_command_event.wait()
 
-                # Update the Watcher backed up data if found.
-                if len(watcher_appointments_data) != 0:
-                    self.watcher.appointments, self.watcher.locator_uuid_map = Builder.build_appointments(
-                        watcher_appointments_data
-                    )
+        self.teardown()
 
-                # Update the Responder with backed up data if found.
-                if len(responder_trackers_data) != 0:
-                    self.watcher.responder.trackers, self.watcher.responder.tx_tracker_map = Builder.build_trackers(
-                        responder_trackers_data
-                    )
+    def setup_components(self):
+        """Performs the initial setup and creates all the components."""
+        watcher_appointments_data = self.db_manager.load_watcher_appointments()
+        responder_trackers_data = self.db_manager.load_responder_trackers()
 
-                # Awaking components so the states can be updated.
-                self.watcher.awake()
-                self.watcher.responder.awake()
+        if len(watcher_appointments_data) == 0 and len(responder_trackers_data) == 0:
+            logger.info("Fresh bootstrap")
 
-                last_block_watcher = self.db_manager.load_last_block_hash_watcher()
-                last_block_responder = self.db_manager.load_last_block_hash_responder()
+            self.watcher.awake()
+            self.watcher.responder.awake()
 
-                # Populate the block queues with data if they've missed some while offline. If the blocks of both match
-                # we don't perform the search twice.
+        else:
+            logger.info("Bootstrapping from backed up data")
 
-                # FIXME: 32-reorgs-offline dropped txs are not used at this point.
-                last_common_ancestor_watcher, dropped_txs_watcher = block_processor.find_last_common_ancestor(
-                    last_block_watcher
+            # Update the Watcher backed up data if found.
+            if len(watcher_appointments_data) != 0:
+                self.watcher.appointments, self.watcher.locator_uuid_map = Builder.build_appointments(
+                    watcher_appointments_data
                 )
-                missed_blocks_watcher = block_processor.get_missed_blocks(last_common_ancestor_watcher)
 
-                if last_block_watcher == last_block_responder:
-                    dropped_txs_responder = dropped_txs_watcher
-                    missed_blocks_responder = missed_blocks_watcher
+            # Update the Responder with backed up data if found.
+            if len(responder_trackers_data) != 0:
+                self.watcher.responder.trackers, self.watcher.responder.tx_tracker_map = Builder.build_trackers(
+                    responder_trackers_data
+                )
 
-                else:
-                    last_common_ancestor_responder, dropped_txs_responder = block_processor.find_last_common_ancestor(
-                        last_block_responder
-                    )
-                    missed_blocks_responder = block_processor.get_missed_blocks(last_common_ancestor_responder)
+            # Awaking components so the states can be updated.
+            self.watcher.awake()
+            self.watcher.responder.awake()
 
-                # If only one of the instances needs to be updated, it can be done separately.
-                if len(missed_blocks_watcher) == 0 and len(missed_blocks_responder) != 0:
-                    Builder.populate_block_queue(self.watcher.responder.block_queue, missed_blocks_responder)
-                    self.watcher.responder.block_queue.join()
+            last_block_watcher = self.db_manager.load_last_block_hash_watcher()
+            last_block_responder = self.db_manager.load_last_block_hash_responder()
 
-                elif len(missed_blocks_responder) == 0 and len(missed_blocks_watcher) != 0:
-                    Builder.populate_block_queue(self.watcher.block_queue, missed_blocks_watcher)
-                    self.watcher.block_queue.join()
+            # Populate the block queues with data if they've missed some while offline. If the blocks of both match
+            # we don't perform the search twice.
 
-                # Otherwise they need to be updated at the same time, block by block
-                elif len(missed_blocks_responder) != 0 and len(missed_blocks_watcher) != 0:
-                    Builder.update_states(self.watcher, missed_blocks_watcher, missed_blocks_responder)
+            # FIXME: 32-reorgs-offline dropped txs are not used at this point.
+            last_common_ancestor_watcher, dropped_txs_watcher = self.block_processor.find_last_common_ancestor(
+                last_block_watcher
+            )
+            missed_blocks_watcher = self.block_processor.get_missed_blocks(last_common_ancestor_watcher)
 
-            # Fire ChainMonitor
-            # FIXME: 92-block-data-during-bootstrap-db
-            self.chain_monitor.monitor_chain()
+            if last_block_watcher == last_block_responder:
+                dropped_txs_responder = dropped_txs_watcher
+                missed_blocks_responder = missed_blocks_watcher
+
+            else:
+                last_common_ancestor_responder, dropped_txs_responder = self.block_processor.find_last_common_ancestor(
+                    last_block_responder
+                )
+                missed_blocks_responder = self.block_processor.get_missed_blocks(last_common_ancestor_responder)
+
+            # If only one of the instances needs to be updated, it can be done separately.
+            if len(missed_blocks_watcher) == 0 and len(missed_blocks_responder) != 0:
+                Builder.populate_block_queue(self.watcher.responder.block_queue, missed_blocks_responder)
+                self.watcher.responder.block_queue.join()
+
+            elif len(missed_blocks_responder) == 0 and len(missed_blocks_watcher) != 0:
+                Builder.populate_block_queue(self.watcher.block_queue, missed_blocks_watcher)
+                self.watcher.block_queue.join()
+
+            # Otherwise they need to be updated at the same time, block by block
+            elif len(missed_blocks_responder) != 0 and len(missed_blocks_watcher) != 0:
+                Builder.update_states(self.watcher, missed_blocks_watcher, missed_blocks_responder)
+
+        # Fire ChainMonitor
+        # FIXME: 92-block-data-during-bootstrap-db
+        self.chain_monitor.monitor_chain()
 
     def start_services(self):
         """Readies the tower by setting up signal handling, and starting all the services."""
@@ -238,22 +244,14 @@ class TeosDaemon:
         signal(SIGQUIT, self.handle_signals)
 
         # Start the internal API
-        self.internal_api = InternalAPI(self.watcher, INTERNAL_API_ENDPOINT, self.stop_command_event)
         self.internal_api.rpc_server.start()
         logger.info(f"Internal API initialized. Serving at {INTERNAL_API_ENDPOINT}")
 
-        # Start the rpc
-        self.rpc_process = multiprocessing.Process(
-            target=rpc.serve,
-            args=(self.config.get("RPC_BIND"), self.config.get("RPC_PORT"), INTERNAL_API_ENDPOINT, self.stop_event),
-            daemon=True,
-        )
+        # Start the rpc process
         self.rpc_process.start()
 
         # Start the public API server
         api_endpoint = f"{self.config.get('API_BIND')}:{self.config.get('API_PORT')}"
-        self.api_popen = None
-        self.api_process = None
         if self.config.get("WSGI") == "gunicorn":
             # FIXME: We may like to add workers depending on a config value
             self.api_popen = subprocess.Popen(
@@ -301,7 +299,7 @@ class TeosDaemon:
 
         logger.info("Terminated public API")
 
-        # Signals readines to shutdown to the other processes
+        # Signals readiness to shutdown to the other processes
         self.stop_event.set()
 
         # wait for RPC process to shutdown
@@ -309,7 +307,7 @@ class TeosDaemon:
 
         # Stops the internal API, after waiting for some grace time
         logger.info("Internal API stopping")
-        self.internal_api.rpc_server.stop(INTERNAL_API_SHUTDOWN_GRACE_TIME).wait()
+        self.internal_api.rpc_server.stop(SHUTDOWN_GRACE_TIME).wait()
         logger.info("Internal API stopped")
 
         # terminate the ChainMonitor
@@ -323,7 +321,11 @@ class TeosDaemon:
 
 
 def main(config):
-    TeosDaemon(config).start()
+    try:
+        TeosDaemon(config).start()
+    except Exception as e:
+        logger.error("An error occurred: {}. Shutting down".format(e))
+        exit(1)
 
 
 if __name__ == "__main__":
@@ -410,6 +412,6 @@ if __name__ == "__main__":
     if config.get("DAEMON"):
         print("Starting TEOS")
         with daemon.DaemonContext():
-            TeosDaemon(config).start()
+            main(config)
     else:
-        TeosDaemon(config).start()
+        main(config)

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -91,7 +91,7 @@ class TeosDaemon:
             logger.error("Cannot connect to bitcoind. Shutting down")
 
         elif not in_correct_network(bitcoind_connect_params, self.config.get("BTC_NETWORK")):
-            logger.error("bitcoind is running on a different network, check conf.py and bitcoin.conf. Shutting down")
+            logger.error("bitcoind is running on a different network, check teos.conf and bitcoin.conf. Shutting down")
 
         else:
             if not os.path.exists(self.config.get("TEOS_SECRET_KEY")) or self.config.get("OVERWRITE_KEY"):

--- a/test/teos/e2e/conftest.py
+++ b/test/teos/e2e/conftest.py
@@ -5,6 +5,7 @@ from time import sleep
 from multiprocessing import Process
 
 from teos.teosd import main
+from teos.cli.teos_cli import RPCClient
 from common.cryptographer import Cryptographer
 from test.teos.conftest import config
 
@@ -16,8 +17,10 @@ def teosd():
 
     yield teosd_process, teos_id
 
+    rpc_client = RPCClient(config.get("RPC_BIND"), config.get("RPC_PORT"))
+    rpc_client.stop()
+    teosd_process.join()
     shutil.rmtree(".teos")
-    teosd_process.terminate()
 
 
 def run_teosd():

--- a/test/teos/e2e/conftest.py
+++ b/test/teos/e2e/conftest.py
@@ -2,12 +2,16 @@ import os
 import shutil
 import pytest
 from time import sleep
+import multiprocessing
+from grpc import RpcError
 from multiprocessing import Process
 
 from teos.teosd import main
 from teos.cli.teos_cli import RPCClient
 from common.cryptographer import Cryptographer
 from test.teos.conftest import config
+
+multiprocessing.set_start_method("spawn")
 
 
 # This fixture needs to be manually run on the first E2E.
@@ -17,8 +21,17 @@ def teosd():
 
     yield teosd_process, teos_id
 
-    rpc_client = RPCClient(config.get("RPC_BIND"), config.get("RPC_PORT"))
-    rpc_client.stop()
+    # FIXME: This is not ideal, but for some reason stop raises socket being closed on the first try here.
+    stopped = False
+    while not stopped:
+        try:
+            rpc_client = RPCClient(config.get("RPC_BIND"), config.get("RPC_PORT"))
+            rpc_client.stop()
+            stopped = True
+        except RpcError:
+            print("failed")
+            pass
+
     teosd_process.join()
     shutil.rmtree(".teos")
 

--- a/test/teos/e2e/test_basic_e2e.py
+++ b/test/teos/e2e/test_basic_e2e.py
@@ -527,5 +527,3 @@ def test_appointment_shutdown_teos_trigger_while_offline(run_bitcoind):
     # The appointment should have been moved to the Responder
     appointment_info = get_appointment_info(locator)
     assert appointment_info.get("status") == "dispute_responded"
-
-    teosd_process.terminate()

--- a/test/teos/e2e/test_basic_e2e.py
+++ b/test/teos/e2e/test_basic_e2e.py
@@ -473,7 +473,10 @@ def test_appointment_shutdown_teos_trigger_back_online(run_bitcoind):
     add_appointment(appointment)
 
     # Restart teos
-    teosd_process.terminate()
+    rpc_client = RPCClient(config.get("RPC_BIND"), config.get("RPC_PORT"))
+    rpc_client.stop()
+    teosd_process.join()
+
     teosd_process, _ = run_teosd()
 
     assert teos_pid != teosd_process.pid
@@ -511,7 +514,10 @@ def test_appointment_shutdown_teos_trigger_while_offline(run_bitcoind):
     assert appointment_info.get("appointment") == appointment.to_dict()
 
     # Shutdown and trigger
-    teosd_process.terminate()
+    rpc_client = RPCClient(config.get("RPC_BIND"), config.get("RPC_PORT"))
+    rpc_client.stop()
+    teosd_process.join()
+
     generate_block_with_transactions(commitment_tx)
 
     # Restart

--- a/test/teos/unit/test_api.py
+++ b/test/teos/unit/test_api.py
@@ -1,4 +1,5 @@
 import pytest
+from multiprocessing import Event
 from shutil import rmtree
 from binascii import hexlify
 
@@ -73,7 +74,7 @@ def internal_api(run_bitcoind, db_manager, gatekeeper, carrier, block_processor)
         db_manager, gatekeeper, block_processor, responder, teos_sk, MAX_APPOINTMENTS, config.get("LOCATOR_CACHE_SIZE")
     )
     watcher.last_known_block = block_processor.get_best_block_hash()
-    i_api = InternalAPI(watcher, INTERNAL_API_ENDPOINT)
+    i_api = InternalAPI(watcher, INTERNAL_API_ENDPOINT, Event())
     i_api.rpc_server.start()
 
     yield i_api


### PR DESCRIPTION
This pull request adds a `stop` command to teos_cli (and consequently to the RPC and the internal API).

Since the service is split among several threads and services, a clean teardown requires some synchronization among them, and services are stopped in the right order to avoid failing requests: public api first, internal rpc and internal api next. Whenever possible, some grace time is given to each service during shutdown.

It also refactors the teosd.py file, by moving all of the code that was in `main()` into a `TeosDaemon` class where it can be split into several methods. A further refactoring in order (possibly splitting the methods into even smaller method) to make the code testable would be a nice followup, but is left as future work.

Closes: #201, #80