### PR TITLE
Improve ChainMonitor to avoid missing blocks during bootstrap

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-timeout
 black
 flake8
 responses

--- a/teos/chain_monitor.py
+++ b/teos/chain_monitor.py
@@ -157,6 +157,7 @@ class ChainMonitor:
         Once the method is fired, it keeps getting the elements added to the internal queue and notifies the receiving
         queues about them. It terminates whenever the internal state is set to ``ChainMonitorStatus.TERMINATED``.
         """
+
         while self.status != ChainMonitorStatus.TERMINATED:
             try:
                 # We add a `timeout` to give the thread a chance to terminate even if the queue is empty

--- a/teos/chain_monitor.py
+++ b/teos/chain_monitor.py
@@ -1,9 +1,17 @@
 from enum import Enum
+from queue import Queue, Empty
 import zmq
 import binascii
 from threading import Thread, Event, Condition
 
 from common.logger import get_logger
+
+
+class ChainMonitorStatus(Enum):
+    IDLE = 0
+    LISTENING = 1
+    ACTIVE = 2
+    TERMINATED = 3
 
 
 class ChainMonitor:
@@ -13,6 +21,19 @@ class ChainMonitor:
 
     The :class:`ChainMonitor` monitors the chain using two methods: ``zmq`` and ``polling``. Blocks are only notified
     once per queue and the notification is triggered by the method that detects the block faster.
+
+    The :class:`ChainMonitor` lifecycle goes through 4 states: idle, listening, active and terminated.
+    When a :class:`ChainMonitor` instance is created, it is not yet monitoring the chain and the ``status`` attribute
+    is set to `ChainMonitorStatus.IDLE`.
+    Once the ``monitor_chain`` method is called, the chain monitor changes ``status`` to
+    `ChainMonitorStatus.LISTENING`, and starts monitoring the chain for new blocks; it does not yet notify the
+    receiving queues, but keeps the block hashes in the order they where spotted in an interna queue.
+    Once the ``activate`` method is called, the ``status`` changes to ``ChainMonitorStatus.ACTIVE``, and the receiving
+    queues are notified in order for all the block hashes that are in the internal queue or any new one that is
+    detected.
+    Finally, once the ``terminate`` method is called, the ``status`` is changed to ``ChainMonitorStatus.TERMINATED``,
+    the chain monitor stops monitoring the chain and no receiving queue will be notified about new blocks (including
+    any block that is currently in the internal queue).
 
     Args:
         receiving_queues (:obj:`list`): a list of ``Queue`` objects that will be notified when the chain_monitor is
@@ -31,13 +52,15 @@ class ChainMonitor:
         zmqSubSocket (:obj:`socket`): a socket to connect to ``bitcoind`` via ``zmq``.
         polling_delta (:obj:`int`): time between polls (in seconds).
         max_block_window_size (:obj:`int`): max size of last_tips.
+        queue (:obj:`Queue`): a ``Queue`` where blocks are stored before they are processed.
+        status (:obj:`ChainMonitorStatus`): the current status of the monitor, either `IDLE`, `LISTENING`, `ACTIVE` or
+            `TERMINATED`.
     """
 
     def __init__(self, receiving_queues, block_processor, bitcoind_feed_params):
         self.logger = get_logger(component=ChainMonitor.__name__)
         self.best_tip = None
         self.last_tips = []
-        self.terminate = False
 
         self.check_tip = Event()
         self.lock = Condition()
@@ -60,6 +83,8 @@ class ChainMonitor:
         self.polling_delta = 60
         self.max_block_window_size = 10
         self.block_processor = block_processor
+        self.queue = Queue()
+        self.status = ChainMonitorStatus.IDLE
 
     def notify_subscribers(self, block_hash):
         """
@@ -70,22 +95,24 @@ class ChainMonitor:
             block_hash (:obj:`str`): the new block hash to be sent to the subscribers.
         """
 
-        for queue in self.receiving_queues:
-            queue.put(block_hash)
+        for rec_queue in self.receiving_queues:
+            rec_queue.put(block_hash)
 
-    def update_state(self, block_hash):
+    def enqueue(self, block_hash):
         """
-        Updates the state of the ``ChainMonitor``. The state is represented as the ``best_tip`` and the list of
-        ``last_tips``. ``last_tips`` is bounded to ``max_block_window_size``.
+        Adds a new block hash to the internal queue of the  ``ChainMonitor`` and the internal state. The state contains
+        the ``best_tip`` field and the list of ``last_tips`` to prevent notfying about old blocks. ``last_tips`` is
+        bounded to ``max_block_window_size``.
 
         Args:
             block_hash (:obj:`block_hash`): the new best tip.
 
         Returns:
-            :obj:`bool`: True is the state was successfully updated, False otherwise.
+            :obj:`bool`: True if the state was successfully updated, False otherwise.
         """
 
         if block_hash != self.best_tip and block_hash not in self.last_tips:
+            self.queue.put(block_hash)
             self.last_tips.append(self.best_tip)
             self.best_tip = block_hash
 
@@ -99,57 +126,98 @@ class ChainMonitor:
 
     def monitor_chain_polling(self):
         """
-        Monitors ``bitcoind`` via polling. Once the method is fired, it keeps monitoring as long as ``terminate`` is not
-        set. Polling is performed once every ``polling_delta`` seconds. If a new best tip if found, the shared lock is
-        acquired, the state is updated and the subscribers are notified, and finally the lock is released.
+        Monitors ``bitcoind`` via polling. Once the method is fired, it keeps monitoring as long as the ``status``
+        attribute is not ``ChainMonitorStatus.TERMINATED``. Polling is performed once every ``polling_delta`` seconds.
+        If a new best tip is found, it is added to the internal queue.
         """
 
-        while not self.terminate:
+        while self.status != ChainMonitorStatus.TERMINATED:
             self.check_tip.wait(timeout=self.polling_delta)
 
             # Terminate could have been set while the thread was blocked in wait
-            if not self.terminate:
+            if self.status != ChainMonitorStatus.TERMINATED:
                 current_tip = self.block_processor.get_best_block_hash()
 
                 # get_best_block_hash may return None if the RPC times out.
-                if current_tip:
-                    self.lock.acquire()
-                    if self.update_state(current_tip):
-                        self.notify_subscribers(current_tip)
-                        self.logger.info("New block received via polling", block_hash=current_tip)
-                    self.lock.release()
+                if current_tip and current_tip not in self.last_tips:
+                    self.logger.info("New block received via polling", block_hash=current_tip)
+                    self.enqueue(current_tip)
 
     def monitor_chain_zmq(self):
         """
-        Monitors ``bitcoind`` via zmq. Once the method is fired, it keeps monitoring as long as ``terminate`` is not
-        set. If a new best tip if found, the shared lock is acquired, the state is updated and the subscribers are
-        notified, and finally the lock is released.
+        Monitors ``bitcoind`` via zmq. Once the method is fired, it keeps monitoring as long as the ``status``
+        attribute is not ``ChainMonitorStatus.TERMINATED``. If a new best tip is found, it is added to the internal
+        queue.
         """
 
-        while not self.terminate:
+        while self.status != ChainMonitorStatus.TERMINATED:
             msg = self.zmqSubSocket.recv_multipart()
 
             # Terminate could have been set while the thread was blocked in recv
-            if not self.terminate:
+            if self.status != ChainMonitorStatus.TERMINATED:
                 topic = msg[0]
                 body = msg[1]
 
                 if topic == b"hashblock":
                     block_hash = binascii.hexlify(body).decode("utf-8")
-
-                    self.lock.acquire()
-                    if self.update_state(block_hash):
-                        self.notify_subscribers(block_hash)
+                    if block_hash not in self.last_tips:
                         self.logger.info("New block received via zmq", block_hash=block_hash)
-                    self.lock.release()
+                        self.enqueue(block_hash)
+
+    def notify_listeners(self):
+        """
+        Once the method is fired, it keeps getting the elements added to the internal queue and notifies the receiving
+        queues about them. It terminates whenever the internal state is set to ``ChainMonitorStatus.TERMINATED``.
+        """
+        while self.status != ChainMonitorStatus.TERMINATED:
+            try:
+                # We add a `timeout` to give the thread a chance to terminate even if the queue is empty
+                block_hash = self.queue.get(block=True, timeout=0.1)
+                with self.lock:
+                    self.notify_subscribers(block_hash)
+            except Empty:
+                pass
 
     def monitor_chain(self):
         """
-        Main :class:`ChainMonitor` method. It initializes the ``best_tip`` to the current one (by querying the
-        :obj:`BlockProcessor <teos.block_processor.BlockProcessor>`) and creates two threads, one per each monitoring
-        approach (``zmq`` and ``polling``).
+        Changes the ``status`` of the :class:`ChainMonitor` from idle to listening. It initializes the ``best_tip`` to
+        the current one (by querying the :obj:`BlockProcessor <teos.block_processor.BlockProcessor>`) and creates two
+        threads, one per each monitoring approach (``zmq`` and ``polling``).
+
+        Raises:
+            :obj:RuntimeError: if the ``status`` was not ``ChainMonitor.IDLE`` when the method was called.
         """
+
+        if self.status != ChainMonitorStatus.IDLE:
+            raise RuntimeError(f"This method can only be called in IDLE status. Current status is {self.status.name}.")
+
+        self.status = ChainMonitorStatus.LISTENING
 
         self.best_tip = self.block_processor.get_best_block_hash()
         Thread(target=self.monitor_chain_polling, daemon=True).start()
         Thread(target=self.monitor_chain_zmq, daemon=True).start()
+
+    def activate(self):
+        """
+        Changes the ``status`` of the :class:`ChainMonitor` from listening to active. It creates a new thread that runs
+        the ``notify_listener`` method, which is in charge of notifying the receiving queue for each block hash that is
+        added to the internal queue.
+
+        Raises:
+            :obj:RuntimeError: if the ``status`` was not ``ChainMonitor.LISTENING`` when the method was called.
+        """
+
+        if self.status != ChainMonitorStatus.LISTENING:
+            raise RuntimeError(
+                f"This method can only be called in LISTENING status. Current status is {self.status.name}."
+            )
+        self.status = ChainMonitorStatus.ACTIVE
+        Thread(target=self.notify_listeners, daemon=True).start()
+
+    def terminate(self):
+        """
+        Changes the ``status`` of the :class:`ChainMonitor` to terminated. All the threads will stop as soon as
+        possible.
+        """
+
+        self.status = ChainMonitorStatus.TERMINATED

--- a/teos/chain_monitor.py
+++ b/teos/chain_monitor.py
@@ -86,18 +86,6 @@ class ChainMonitor:
         self.queue = Queue()
         self.status = ChainMonitorStatus.IDLE
 
-    def notify_subscribers(self, block_hash):
-        """
-        Notifies the subscribers (``Watcher`` and ``Responder``) about a new block. It does so by putting the hash in
-        the corresponding queue(s).
-
-        Args:
-            block_hash (:obj:`str`): the new block hash to be sent to the subscribers.
-        """
-
-        for rec_queue in self.receiving_queues:
-            rec_queue.put(block_hash)
-
     def enqueue(self, block_hash):
         """
         Adds a new block hash to the internal queue of the  ``ChainMonitor`` and the internal state. The state contains
@@ -174,7 +162,8 @@ class ChainMonitor:
                 # We add a `timeout` to give the thread a chance to terminate even if the queue is empty
                 block_hash = self.queue.get(block=True, timeout=0.1)
                 with self.lock:
-                    self.notify_subscribers(block_hash)
+                    for rec_queue in self.receiving_queues:
+                        rec_queue.put(block_hash)
             except Empty:
                 pass
 

--- a/teos/chain_monitor.py
+++ b/teos/chain_monitor.py
@@ -89,11 +89,11 @@ class ChainMonitor:
     def enqueue(self, block_hash):
         """
         Adds a new block hash to the internal queue of the  ``ChainMonitor`` and the internal state. The state contains
-        the ``best_tip`` field and the list of ``last_tips`` to prevent notfying about old blocks. ``last_tips`` is
+        the ``best_tip`` field and the list of ``last_tips`` to prevent notifying about old blocks. ``last_tips`` is
         bounded to ``max_block_window_size``.
 
         Args:
-            block_hash (:obj:`block_hash`): the new best tip.
+            block_hash (:obj:`str`): the new best tip.
 
         Returns:
             :obj:`bool`: True if the state was successfully updated, False otherwise.
@@ -127,7 +127,7 @@ class ChainMonitor:
                 current_tip = self.block_processor.get_best_block_hash()
 
                 # get_best_block_hash may return None if the RPC times out.
-                if current_tip and current_tip not in self.last_tips:
+                if current_tip and current_tip != self.best_tip and current_tip not in self.last_tips:
                     self.logger.info("New block received via polling", block_hash=current_tip)
                     self.enqueue(current_tip)
 
@@ -148,7 +148,7 @@ class ChainMonitor:
 
                 if topic == b"hashblock":
                     block_hash = binascii.hexlify(body).decode("utf-8")
-                    if block_hash not in self.last_tips:
+                    if block_hash != self.best_tip and block_hash not in self.last_tips:
                         self.logger.info("New block received via zmq", block_hash=block_hash)
                         self.enqueue(block_hash)
 

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -155,6 +155,9 @@ class TeosDaemon:
         case the tower has been offline for some time. Finally, it starts the chain monitor.
         """
 
+        # Make sure that the ChainMonitor starts listening to new blocks while we bootstrap
+        self.chain_monitor.monitor_chain()
+
         watcher_appointments_data = self.db_manager.load_watcher_appointments()
         responder_trackers_data = self.db_manager.load_responder_trackers()
 
@@ -218,9 +221,8 @@ class TeosDaemon:
             elif len(missed_blocks_responder) != 0 and len(missed_blocks_watcher) != 0:
                 Builder.update_states(self.watcher, missed_blocks_watcher, missed_blocks_responder)
 
-        # Fire ChainMonitor
-        # FIXME: 92-block-data-during-bootstrap-db
-        self.chain_monitor.monitor_chain()
+        # Activate ChainMonitor
+        self.chain_monitor.activate()
 
     def start_services(self):
         """Readies the tower by setting up signal handling, and starting all the services."""
@@ -298,7 +300,7 @@ class TeosDaemon:
         logger.info("Internal API stopped")
 
         # terminate the ChainMonitor
-        self.chain_monitor.terminate = True
+        self.chain_monitor.terminate()
 
         logger.info("Closing connection with appointments db")
         self.db_manager.db.close()

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -302,6 +302,10 @@ class TeosDaemon:
         # terminate the ChainMonitor
         self.chain_monitor.terminate()
 
+        # wait for watcher and responder to finish processing their queues
+        self.watcher.join()
+        self.watcher.responder.join()
+
         logger.info("Closing connection with appointments db")
         self.db_manager.db.close()
 

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -72,6 +72,10 @@ class TeosDaemon:
         block_processor (:obj:`teos.block_processor.BlockProcessor`): the BlockProcessor instance.
         db_manager (:obj:`teos.appointments_dbm.AppointmentsDBM`): the db manager for appointments.
         watcher (:obj:`teos.watcher.Watcher`): the `Watcher` instance.
+        watcher_thread (:obj:`multithreading.Thread` or :obj:`None`): after ``bootstrap_components``, the thread that
+            runs the Watcher monitoring.
+        responder_thread (:obj:`multithreading.Thread` or :obj:`None`): after ``bootstrap_components``, the thread that
+            runs the Responder monitoring.
         chain_monitor (:obj:`teos.chain_monitor.ChainMonitor`): the ``ChainMonitor`` instance.
         self.api_proc (:obj:`subprocess.Popen` or :obj:`multiprocessing.Process` or :obj:`None`): once the rpc process
             is created, the instance of either ``Popen`` or ``Process`` that is serving the public API.
@@ -123,6 +127,9 @@ class TeosDaemon:
             self.config.get("LOCATOR_CACHE_SIZE"),
         )
 
+        self.watcher_thread = None
+        self.responder_thread = None
+
         # Create the chain monitor
         self.chain_monitor = ChainMonitor(
             [self.watcher.block_queue, self.watcher.responder.block_queue], self.block_processor, bitcoind_feed_params
@@ -164,8 +171,8 @@ class TeosDaemon:
         if len(watcher_appointments_data) == 0 and len(responder_trackers_data) == 0:
             logger.info("Fresh bootstrap")
 
-            self.watcher.awake()
-            self.watcher.responder.awake()
+            self.watcher_thread = self.watcher.awake()
+            self.responder_thread = self.watcher.responder.awake()
 
         else:
             logger.info("Bootstrapping from backed up data")
@@ -183,8 +190,8 @@ class TeosDaemon:
                 )
 
             # Awaking components so the states can be updated.
-            self.watcher.awake()
-            self.watcher.responder.awake()
+            self.watcher_thread = self.watcher.awake()
+            self.responder_thread = self.watcher.responder.awake()
 
             last_block_watcher = self.db_manager.load_last_block_hash_watcher()
             last_block_responder = self.db_manager.load_last_block_hash_responder()
@@ -303,8 +310,8 @@ class TeosDaemon:
         self.chain_monitor.terminate()
 
         # wait for watcher and responder to finish processing their queues
-        self.watcher.join()
-        self.watcher.responder.join()
+        self.watcher_thread.join()
+        self.responder_thread.join()
 
         logger.info("Closing connection with appointments db")
         self.db_manager.db.close()

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -125,7 +125,7 @@ class TeosDaemon:
 
         # Create the chain monitor
         self.chain_monitor = ChainMonitor(
-            self.watcher.block_queue, self.watcher.responder.block_queue, self.block_processor, bitcoind_feed_params
+            [self.watcher.block_queue, self.watcher.responder.block_queue], self.block_processor, bitcoind_feed_params
         )
 
         # Set up the internal API

--- a/test/teos/unit/test_chain_monitor.py
+++ b/test/teos/unit/test_chain_monitor.py
@@ -3,7 +3,7 @@ import time
 from queue import Queue
 from threading import Thread, Event, Condition
 
-from teos.chain_monitor import ChainMonitor
+from teos.chain_monitor import ChainMonitor, ChainMonitorStatus
 
 from test.teos.conftest import generate_blocks
 from test.teos.unit.conftest import get_random_value_hex, bitcoind_feed_params
@@ -17,7 +17,7 @@ def test_init(block_processor):
 
     assert chain_monitor.best_tip is None
     assert isinstance(chain_monitor.last_tips, list) and len(chain_monitor.last_tips) == 0
-    assert chain_monitor.terminate is False
+    assert chain_monitor.status == ChainMonitorStatus.IDLE
     assert isinstance(chain_monitor.check_tip, Event)
     assert isinstance(chain_monitor.lock, Condition)
     assert isinstance(chain_monitor.zmqSubSocket, zmq.Socket)
@@ -42,7 +42,7 @@ def test_notify_subscribers(block_processor):
     assert chain_monitor.receiving_queues[1].get() == new_block
 
 
-def test_update_state(block_processor):
+def test_enqueue(block_processor):
     # The state is updated after receiving a new block (and only if the block is not already known).
     # Let's start by setting a best_tip and a couple of old tips
     new_block_hash = get_random_value_hex(32)
@@ -51,41 +51,39 @@ def test_update_state(block_processor):
     chain_monitor.last_tips = [get_random_value_hex(32) for _ in range(5)]
 
     # Now we can try to update the state with an old best_tip and see how it doesn't work
-    assert chain_monitor.update_state(chain_monitor.last_tips[0]) is False
+    assert chain_monitor.enqueue(chain_monitor.last_tips[0]) is False
 
     # Same should happen with the current tip
-    assert chain_monitor.update_state(chain_monitor.best_tip) is False
+    assert chain_monitor.enqueue(chain_monitor.best_tip) is False
 
     # The state should be correctly updated with a new block hash, the chain tip should change and the old tip should
     # have been added to the last_tips
     another_block_hash = get_random_value_hex(32)
-    assert chain_monitor.update_state(another_block_hash) is True
+    assert chain_monitor.enqueue(another_block_hash) is True
     assert chain_monitor.best_tip == another_block_hash and new_block_hash == chain_monitor.last_tips[-1]
 
 
 def test_monitor_chain_polling(block_processor):
-    # Try polling with the Watcher
-    watcher_queue = Queue()
-    chain_monitor = ChainMonitor([watcher_queue, Queue()], block_processor, bitcoind_feed_params)
+    chain_monitor = ChainMonitor([Queue(), Queue()], block_processor, bitcoind_feed_params)
     chain_monitor.best_tip = block_processor.get_best_block_hash()
     chain_monitor.polling_delta = 0.1
 
-    # monitor_chain_polling runs until terminate if set
+    # monitor_chain_polling runs until not terminated
     polling_thread = Thread(target=chain_monitor.monitor_chain_polling, daemon=True)
     polling_thread.start()
 
     # Check that nothing changes as long as a block is not generated
     for _ in range(5):
-        assert chain_monitor.receiving_queues[0].empty()
+        assert chain_monitor.queue.empty()
         time.sleep(0.1)
 
     # And that it does if we generate a block
     generate_blocks(1)
 
-    chain_monitor.receiving_queues[0].get()
-    assert chain_monitor.receiving_queues[0].empty()
+    chain_monitor.queue.get()
+    assert chain_monitor.queue.empty()
 
-    chain_monitor.terminate = True
+    chain_monitor.terminate()
 
 
 def test_monitor_chain_zmq(block_processor):
@@ -96,25 +94,52 @@ def test_monitor_chain_zmq(block_processor):
     zmq_thread = Thread(target=chain_monitor.monitor_chain_zmq, daemon=True)
     zmq_thread.start()
 
-    # Queues should start empty
-    assert chain_monitor.receiving_queues[1].empty()
+    # the internal queue should start empty
+    assert chain_monitor.queue.empty()
 
     # And have a new block every time we generate one
     for _ in range(3):
         generate_blocks(1)
 
-        chain_monitor.receiving_queues[1].get()
-        assert chain_monitor.receiving_queues[1].empty()
+        chain_monitor.queue.get()
+        assert chain_monitor.queue.empty()
 
-    chain_monitor.terminate = True
+    chain_monitor.terminate()
     # The zmq thread needs a block generation to release from the recv method.
     generate_blocks(1)
 
 
 def test_monitor_chain(block_processor):
+    # We don't activate it but we start listening; therefore received blocks should accumulate in the internal queue
+    chain_monitor = ChainMonitor([Queue(), Queue()], block_processor, bitcoind_feed_params)
+    chain_monitor.polling_delta = 0.1
+
+    chain_monitor.monitor_chain()
+
+    # The tip is updated before starting the threads, so it should have changed.
+    assert chain_monitor.best_tip is not None
+
+    # Blocks should be received
+    count = 0
+    for _ in range(5):
+        generate_blocks(1)
+        count += 1
+        time.sleep(0.5)  # higher than the polling interval
+        print(f"Best block: {block_processor.get_best_block_hash()}")
+        assert chain_monitor.receiving_queues[0].empty()
+        assert chain_monitor.receiving_queues[1].empty()
+        assert chain_monitor.queue.qsize() == count
+
+    chain_monitor.terminate()
+    # The zmq thread needs a block generation to release from the recv method.
+    generate_blocks(1)
+
+
+def test_activate(block_processor):
     # Not much to test here, this should launch two threads (one per monitor approach) and finish on terminate
     chain_monitor = ChainMonitor([Queue(), Queue()], block_processor, bitcoind_feed_params)
     chain_monitor.monitor_chain()
+    chain_monitor.activate()
 
     # The tip is updated before starting the threads, so it should have changed.
     assert chain_monitor.best_tip is not None
@@ -128,7 +153,7 @@ def test_monitor_chain(block_processor):
         assert chain_monitor.receiving_queues[0].empty()
         assert chain_monitor.receiving_queues[1].empty()
 
-    chain_monitor.terminate = True
+    chain_monitor.terminate()
     # The zmq thread needs a block generation to release from the recv method.
     generate_blocks(1)
 
@@ -143,6 +168,7 @@ def test_monitor_chain_single_update(block_processor):
     # We will create a block and wait for the polling thread. Then check the queues to see that the block hash has only
     # been added once.
     chain_monitor.monitor_chain()
+    chain_monitor.activate()
     generate_blocks(1)
 
     assert len(chain_monitor.receiving_queues) == 2
@@ -159,4 +185,8 @@ def test_monitor_chain_single_update(block_processor):
     assert chain_monitor.receiving_queues[1].empty()
 
     # We can also force an update and see that it won't go through
-    assert chain_monitor.update_state(queue0_block) is False
+    assert chain_monitor.enqueue(queue0_block) is False
+
+    chain_monitor.terminate()
+    # The zmq thread needs a block generation to release from the recv method.
+    generate_blocks(1)

--- a/test/teos/unit/test_responder.py
+++ b/test/teos/unit/test_responder.py
@@ -28,7 +28,7 @@ from test.teos.unit.conftest import get_random_value_hex, bitcoind_feed_params
 @pytest.fixture(scope="module")
 def responder(db_manager, gatekeeper, carrier, block_processor):
     responder = Responder(db_manager, gatekeeper, carrier, block_processor)
-    chain_monitor = ChainMonitor(Queue(), responder.block_queue, block_processor, bitcoind_feed_params)
+    chain_monitor = ChainMonitor([Queue(), responder.block_queue], block_processor, bitcoind_feed_params)
     chain_monitor.monitor_chain()
 
     return responder
@@ -297,7 +297,7 @@ def test_do_watch(temp_db_manager, gatekeeper, carrier, block_processor, generat
 
     # Create a fresh responder to simplify the test
     responder = Responder(temp_db_manager, gatekeeper, carrier, block_processor)
-    chain_monitor = ChainMonitor(Queue(), responder.block_queue, block_processor, bitcoind_feed_params)
+    chain_monitor = ChainMonitor([Queue(), responder.block_queue], block_processor, bitcoind_feed_params)
     chain_monitor.monitor_chain()
 
     # Let's set up the trackers first
@@ -360,7 +360,7 @@ def test_do_watch(temp_db_manager, gatekeeper, carrier, block_processor, generat
 
 def test_check_confirmations(db_manager, gatekeeper, carrier, block_processor):
     responder = Responder(db_manager, gatekeeper, carrier, block_processor)
-    chain_monitor = ChainMonitor(Queue(), responder.block_queue, block_processor, bitcoind_feed_params)
+    chain_monitor = ChainMonitor([Queue(), responder.block_queue], block_processor, bitcoind_feed_params)
     chain_monitor.monitor_chain()
 
     # check_confirmations checks, given a list of transaction for a block, what of the known penalty transaction have
@@ -416,7 +416,7 @@ def test_get_txs_to_rebroadcast(responder):
 
 def test_get_completed_trackers(db_manager, gatekeeper, carrier, block_processor, generate_dummy_tracker):
     responder = Responder(db_manager, gatekeeper, carrier, block_processor)
-    chain_monitor = ChainMonitor(Queue(), responder.block_queue, block_processor, bitcoind_feed_params)
+    chain_monitor = ChainMonitor([Queue(), responder.block_queue], block_processor, bitcoind_feed_params)
     chain_monitor.monitor_chain()
 
     commitment_txs = [create_commitment_tx() for _ in range(30)]
@@ -537,7 +537,7 @@ def test_get_expired_trackers(responder, generate_dummy_tracker):
 
 def test_rebroadcast(db_manager, gatekeeper, carrier, block_processor, generate_dummy_tracker):
     responder = Responder(db_manager, gatekeeper, carrier, block_processor)
-    chain_monitor = ChainMonitor(Queue(), responder.block_queue, block_processor, bitcoind_feed_params)
+    chain_monitor = ChainMonitor([Queue(), responder.block_queue], block_processor, bitcoind_feed_params)
     chain_monitor.monitor_chain()
 
     # Include the commitment txs in a block

--- a/test/teos/unit/test_responder.py
+++ b/test/teos/unit/test_responder.py
@@ -299,6 +299,7 @@ def test_do_watch(temp_db_manager, gatekeeper, carrier, block_processor, generat
     responder = Responder(temp_db_manager, gatekeeper, carrier, block_processor)
     chain_monitor = ChainMonitor([Queue(), responder.block_queue], block_processor, bitcoind_feed_params)
     chain_monitor.monitor_chain()
+    chain_monitor.activate()
 
     # Let's set up the trackers first
     for tracker in trackers:

--- a/test/teos/unit/test_responder.py
+++ b/test/teos/unit/test_responder.py
@@ -25,13 +25,18 @@ from test.teos.conftest import (
 from test.teos.unit.conftest import get_random_value_hex, bitcoind_feed_params
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def responder(db_manager, gatekeeper, carrier, block_processor):
     responder = Responder(db_manager, gatekeeper, carrier, block_processor)
     chain_monitor = ChainMonitor([Queue(), responder.block_queue], block_processor, bitcoind_feed_params)
     chain_monitor.monitor_chain()
+    responder.awake()
+    chain_monitor.activate()
 
-    return responder
+    yield responder
+
+    chain_monitor.terminate()
+    responder.join()
 
 
 # FIXME: Check if this can be removed and used the general fixture
@@ -108,8 +113,7 @@ def test_tracker_get_summary(generate_dummy_tracker):
     }
 
 
-def test_init_responder(temp_db_manager, gatekeeper, carrier, block_processor):
-    responder = Responder(temp_db_manager, gatekeeper, carrier, block_processor)
+def test_init_responder(temp_db_manager, gatekeeper, carrier, block_processor, responder):
     assert isinstance(responder.trackers, dict) and len(responder.trackers) == 0
     assert isinstance(responder.tx_tracker_map, dict) and len(responder.tx_tracker_map) == 0
     assert isinstance(responder.unconfirmed_txs, list) and len(responder.unconfirmed_txs) == 0
@@ -139,9 +143,7 @@ def test_on_sync_fail(responder, block_processor):
     assert responder.on_sync(chain_tip) is False
 
 
-def test_handle_breach(db_manager, gatekeeper, carrier, block_processor, generate_dummy_tracker):
-    responder = Responder(db_manager, gatekeeper, carrier, block_processor)
-
+def test_handle_breach(db_manager, gatekeeper, carrier, responder, block_processor, generate_dummy_tracker):
     uuid = uuid4().hex
     commitment_tx = create_commitment_tx()
     tracker = generate_dummy_tracker(commitment_tx)
@@ -161,10 +163,11 @@ def test_handle_breach(db_manager, gatekeeper, carrier, block_processor, generat
     assert receipt.delivered is True
 
 
-def test_handle_breach_bad_response(db_manager, gatekeeper, carrier, block_processor, generate_dummy_tracker):
+def test_handle_breach_bad_response(
+    db_manager, gatekeeper, carrier, responder, block_processor, generate_dummy_tracker
+):
     # We need a new carrier here, otherwise the transaction will be flagged as previously sent and receipt.delivered
     # will be True
-    responder = Responder(db_manager, gatekeeper, carrier, block_processor)
 
     uuid = uuid4().hex
     commitment_tx = create_commitment_tx()
@@ -359,11 +362,7 @@ def test_do_watch(temp_db_manager, gatekeeper, carrier, block_processor, generat
         assert len(responder.gatekeeper.registered_users[tracker.user_id].appointments) == 0
 
 
-def test_check_confirmations(db_manager, gatekeeper, carrier, block_processor):
-    responder = Responder(db_manager, gatekeeper, carrier, block_processor)
-    chain_monitor = ChainMonitor([Queue(), responder.block_queue], block_processor, bitcoind_feed_params)
-    chain_monitor.monitor_chain()
-
+def test_check_confirmations(db_manager, gatekeeper, carrier, responder, block_processor):
     # check_confirmations checks, given a list of transaction for a block, what of the known penalty transaction have
     # been confirmed. To test this we need to create a list of transactions and the state of the Responder
     txs = [get_random_value_hex(32) for _ in range(20)]
@@ -415,11 +414,7 @@ def test_get_txs_to_rebroadcast(responder):
     assert txs_to_rebroadcast == list(txs_missing_too_many_conf.keys())
 
 
-def test_get_completed_trackers(db_manager, gatekeeper, carrier, block_processor, generate_dummy_tracker):
-    responder = Responder(db_manager, gatekeeper, carrier, block_processor)
-    chain_monitor = ChainMonitor([Queue(), responder.block_queue], block_processor, bitcoind_feed_params)
-    chain_monitor.monitor_chain()
-
+def test_get_completed_trackers(db_manager, gatekeeper, carrier, responder, block_processor, generate_dummy_tracker):
     commitment_txs = [create_commitment_tx() for _ in range(30)]
     generate_block_with_transactions(commitment_txs)
     # A complete tracker is a tracker whose penalty transaction has been irrevocably resolved (i.e. has reached 100
@@ -536,11 +531,7 @@ def test_get_expired_trackers(responder, generate_dummy_tracker):
     )
 
 
-def test_rebroadcast(db_manager, gatekeeper, carrier, block_processor, generate_dummy_tracker):
-    responder = Responder(db_manager, gatekeeper, carrier, block_processor)
-    chain_monitor = ChainMonitor([Queue(), responder.block_queue], block_processor, bitcoind_feed_params)
-    chain_monitor.monitor_chain()
-
+def test_rebroadcast(db_manager, gatekeeper, carrier, responder, block_processor, generate_dummy_tracker):
     # Include the commitment txs in a block
     commitment_txs = [create_commitment_tx() for _ in range(20)]
     generate_block_with_transactions(commitment_txs)

--- a/test/teos/unit/test_responder.py
+++ b/test/teos/unit/test_responder.py
@@ -30,13 +30,13 @@ def responder(db_manager, gatekeeper, carrier, block_processor):
     responder = Responder(db_manager, gatekeeper, carrier, block_processor)
     chain_monitor = ChainMonitor([Queue(), responder.block_queue], block_processor, bitcoind_feed_params)
     chain_monitor.monitor_chain()
-    responder.awake()
+    responder_thread = responder.awake()
     chain_monitor.activate()
 
     yield responder
 
     chain_monitor.terminate()
-    responder.join()
+    responder_thread.join()
 
 
 # FIXME: Check if this can be removed and used the general fixture

--- a/test/teos/unit/test_watcher.py
+++ b/test/teos/unit/test_watcher.py
@@ -80,7 +80,7 @@ def watcher(run_bitcoind, db_manager, gatekeeper):
     watcher.last_known_block = block_processor.get_best_block_hash()
 
     chain_monitor = ChainMonitor(
-        watcher.block_queue, watcher.responder.block_queue, block_processor, bitcoind_feed_params
+        [watcher.block_queue, watcher.responder.block_queue], block_processor, bitcoind_feed_params
     )
     chain_monitor.monitor_chain()
 

--- a/test/teos/unit/test_watcher.py
+++ b/test/teos/unit/test_watcher.py
@@ -83,6 +83,7 @@ def watcher(run_bitcoind, db_manager, gatekeeper):
         [watcher.block_queue, watcher.responder.block_queue], block_processor, bitcoind_feed_params
     )
     chain_monitor.monitor_chain()
+    chain_monitor.activate()
 
     return watcher
 


### PR DESCRIPTION
Added a multi-state life-cycle to the ChainMonitor. Also generalized to accept an arbitrary number of subscribers, instead of the two that we're currently using.

It is IDLE when created, it listens but does not notifies subscribers when LISTENING, it listens and notifies subscribers when ACTIVE, it stop any actions when TERMINATED.

Also improved the shutdown code to properly wait for a graceful termination of Watcher and Responder threads.

Closes: #92 