### PR TITLE
Modified API to reuse the grpc stub

### DIFF
--- a/teos/cli/teos_cli.py
+++ b/teos/cli/teos_cli.py
@@ -62,15 +62,14 @@ class RPCClient:
         rpc_port (:obj:`int`): the port where the RPC server will be hosted.
 
     Attributes:
-        channel (:obj:`grpc.Channel`): The :obj:`Channel` object.
         stub: The rpc client stub.
     """
 
     def __init__(self, rpc_host, rpc_port):
         self.rpc_host = rpc_host
         self.rpc_port = rpc_port
-        self.channel = grpc.insecure_channel(f"{rpc_host}:{rpc_port}")
-        self.stub = TowerServicesStub(self.channel)
+        channel = grpc.insecure_channel(f"{rpc_host}:{rpc_port}")
+        self.stub = TowerServicesStub(channel)
 
     @formatted
     def get_all_appointments(self):

--- a/teos/rpc.py
+++ b/teos/rpc.py
@@ -67,13 +67,16 @@ class _RPC(TowerServicesServicer):
     Args:
         internal_api_endpoint (:obj:`str`): the endpoint where to reach the internal (gRPC) api.
         logger (:obj:`Logger <teos.logger.Logger>`): the logger for this component.
+
+    Attributes:
+        stub (:obj:`TowerServicesStub`): The rpc client stub.
     """
 
     def __init__(self, internal_api_endpoint, logger):
         self.logger = logger
         self.internal_api_endpoint = internal_api_endpoint
-        self.channel = grpc.insecure_channel(self.internal_api_endpoint)
-        self.stub = TowerServicesStub(self.channel)
+        channel = grpc.insecure_channel(self.internal_api_endpoint)
+        self.stub = TowerServicesStub(channel)
 
     @forward_errors
     def get_all_appointments(self, request, context):


### PR DESCRIPTION
It looks like reusing the channel/stub is the correct way of making repeated grpc requests, as channels already support multiplexing concurrent requests on them.

This PR recycles the `stub` for the `API` class, and adds missing attribute docs for `_RPC`.

Closes: #193 