### PR TITLE
Removes instances of binascii and struct

### DIFF
--- a/common/appointment.py
+++ b/common/appointment.py
@@ -1,5 +1,4 @@
 import struct
-from binascii import unhexlify
 
 
 class Appointment:
@@ -68,4 +67,4 @@ class Appointment:
         Returns:
               :obj:`bytes`: The serialized data to be signed.
         """
-        return unhexlify(self.locator) + unhexlify(self.encrypted_blob) + struct.pack(">I", self.to_self_delay)
+        return bytes.fromhex(self.locator) + bytes.fromhex(self.encrypted_blob) + self.to_self_delay.to_bytes(4, "big")

--- a/common/receipts.py
+++ b/common/receipts.py
@@ -1,6 +1,5 @@
 import struct
 import pyzbase32
-from binascii import unhexlify
 
 from common.tools import is_compressed_pk, is_u4int
 from common.exceptions import InvalidParameter
@@ -32,7 +31,7 @@ def create_registration_receipt(user_id, available_slots, subscription_expiry):
     elif not is_u4int(subscription_expiry):
         raise InvalidParameter("Provided subscription_expiry must be a 4-byte unsigned integer")
 
-    return unhexlify(user_id) + struct.pack(">I", available_slots) + struct.pack(">I", subscription_expiry)
+    return bytes.fromhex(user_id) + available_slots.to_bytes(4, "big") + subscription_expiry.to_bytes(4, "big")
 
 
 def create_appointment_receipt(user_signature, start_block):

--- a/contrib/client/teos_client.py
+++ b/contrib/client/teos_client.py
@@ -4,7 +4,6 @@ import os
 import sys
 import time
 import json
-import binascii
 import requests
 from logging import getLogger
 from sys import argv
@@ -436,7 +435,7 @@ def main(command, args, command_line_conf):
                 logger.info("Subscription expires at block {}".format(subscription_expiry))
 
                 teos_id_file = os.path.join(config.get("DATA_DIR"), "teos_pk")
-                Cryptographer.save_key_file(binascii.unhexlify(teos_id), teos_id_file, config.get("DATA_DIR"))
+                Cryptographer.save_key_file(bytes.fromhex(teos_id), teos_id_file, config.get("DATA_DIR"))
 
         if command == "add_appointment":
             teos_id = load_teos_id(config.get("TEOS_PUBLIC_KEY"))

--- a/teos/chain_monitor.py
+++ b/teos/chain_monitor.py
@@ -1,7 +1,6 @@
 from enum import Enum
 from queue import Queue
 import zmq
-import binascii
 from threading import Thread, Event, Condition
 
 from teos.logger import get_logger
@@ -139,7 +138,7 @@ class ChainMonitor:
             body = msg[1]
 
             if topic == b"hashblock":
-                block_hash = binascii.hexlify(body).decode("utf-8")
+                block_hash = body.hex()
                 if block_hash not in self.last_tips:
                     self.logger.info("New block received via zmq", block_hash=block_hash)
                     self.enqueue(block_hash)

--- a/test/common/unit/test_appointment.py
+++ b/test/common/unit/test_appointment.py
@@ -1,6 +1,5 @@
 import struct
 import pytest
-import binascii
 
 from common.appointment import Appointment
 
@@ -63,6 +62,6 @@ def test_serialize(appointment_data):
     encrypted_blob = serialized_appointment[16:-4]
     to_self_delay = serialized_appointment[-4:]
 
-    assert binascii.hexlify(locator).decode() == appointment.locator
-    assert binascii.hexlify(encrypted_blob).decode() == appointment.encrypted_blob
-    assert struct.unpack(">I", to_self_delay)[0] == appointment.to_self_delay
+    assert locator.hex() == appointment.locator
+    assert encrypted_blob.hex() == appointment.encrypted_blob
+    assert int.from_bytes(to_self_delay, "big") == appointment.to_self_delay

--- a/test/common/unit/test_receipts.py
+++ b/test/common/unit/test_receipts.py
@@ -1,7 +1,6 @@
 import struct
 import pytest
 import pyzbase32
-from binascii import hexlify
 from coincurve import PrivateKey
 
 from common import receipts as receipts
@@ -21,9 +20,9 @@ def test_create_registration_receipt():
 
     registration_receipt = receipts.create_registration_receipt(user_id, available_slots, subscription_expiry)
 
-    assert hexlify(registration_receipt[:33]).decode() == user_id
-    assert struct.unpack(">I", registration_receipt[33:37])[0] == available_slots
-    assert struct.unpack(">I", registration_receipt[37:])[0] == subscription_expiry
+    assert registration_receipt[:33].hex() == user_id
+    assert int.from_bytes(registration_receipt[33:37], "big") == available_slots
+    assert int.from_bytes(registration_receipt[37:], "big") == subscription_expiry
 
 
 def test_create_registration_receipt_wrong_inputs():

--- a/test/teos/e2e/test_basic_e2e.py
+++ b/test/teos/e2e/test_basic_e2e.py
@@ -2,7 +2,6 @@ import pytest
 import json
 from time import sleep
 from riemann.tx import Tx
-from binascii import hexlify
 from coincurve import PrivateKey
 
 from contrib.client import teos_client
@@ -317,7 +316,7 @@ def test_two_identical_appointments(run_bitcoind):
 #
 #     # tmp keys from a different user
 #     tmp_user_sk = PrivateKey()
-#     tmp_user_id = hexlify(tmp_user_sk.public_key.format(compressed=True)).decode("utf-8")
+#     tmp_user_id = Cryptographer.get_compressed_pk(tmp_user_sk.public_key)
 #     teos_client.register(tmp_user_id, teos_base_endpoint)
 #
 #     # Send the appointment twice
@@ -364,7 +363,7 @@ def test_two_appointment_same_locator_different_penalty_different_users(run_bitc
 
     # tmp keys for a different user
     tmp_user_sk = PrivateKey()
-    tmp_user_id = hexlify(tmp_user_sk.public_key.format(compressed=True)).decode("utf-8")
+    tmp_user_id = Cryptographer.get_compressed_pk(tmp_user_sk.public_key)
     teos_client.register(tmp_user_id, teos_id, teos_base_endpoint)
 
     appointment_1 = teos_client.create_appointment(appointment1_data)

--- a/test/teos/unit/test_inspector.py
+++ b/test/teos/unit/test_inspector.py
@@ -1,5 +1,4 @@
 import pytest
-from binascii import unhexlify
 
 import common.errors as errors
 from teos.inspector import Inspector, InspectionFailed
@@ -27,7 +26,7 @@ WRONG_TYPES = [
     " " * LOCATOR_LEN_HEX,
     object(),
 ]
-WRONG_TYPES_NO_STR = [[], unhexlify(get_random_value_hex(LOCATOR_LEN_BYTES)), 3.2, 2.0, (), object, {}, object()]
+WRONG_TYPES_NO_STR = [[], bytes.fromhex(get_random_value_hex(LOCATOR_LEN_BYTES)), 3.2, 2.0, (), object, {}, object()]
 
 MIN_TO_SELF_DELAY = config.get("MIN_TO_SELF_DELAY")
 inspector = Inspector(MIN_TO_SELF_DELAY)

--- a/test/teos/unit/test_internal_api.py
+++ b/test/teos/unit/test_internal_api.py
@@ -1,7 +1,6 @@
 from multiprocessing import Event
 import grpc
 import pytest
-from binascii import hexlify
 from uuid import uuid4
 
 from google.protobuf import json_format
@@ -34,7 +33,7 @@ MAX_APPOINTMENTS = 100
 teos_sk, teos_pk = generate_keypair()
 
 user_sk, user_pk = generate_keypair()
-user_id = hexlify(user_pk.format(compressed=True)).decode("utf-8")
+user_id = Cryptographer.get_compressed_pk(user_pk)
 
 
 @pytest.fixture(scope="module")

--- a/watchtower-plugin/net/http.py
+++ b/watchtower-plugin/net/http.py
@@ -1,5 +1,4 @@
 import json
-import binascii
 import requests
 from requests import ConnectionError, ConnectTimeout
 from requests.exceptions import MissingSchema, InvalidSchema, InvalidURL
@@ -88,7 +87,7 @@ def send_appointment(tower_id, tower, appointment_dict, signature):
             tower_id=tower_id,
             recovered_id=recovered_id,
             signature=tower_signature,
-            receipt=binascii.hexlify(appointment_receipt).decode(),
+            receipt=appointment_receipt.hex(),
         )
 
     return response

--- a/watchtower-plugin/test_watchtower.py
+++ b/watchtower-plugin/test_watchtower.py
@@ -1,18 +1,19 @@
+import configparser
+import logging
 import os
 import random
-import pytest
 import shutil
-import logging
-import configparser
-from time import sleep
-from coincurve import PrivateKey
 from threading import Thread
+from time import sleep
+
+import pytest
+from coincurve import PrivateKey
 from flask import Flask, request, jsonify
 from pyln.testing.fixtures import *  # noqa: F401,F403
 
-from common import errors
-from common import constants
 import common.receipts as receipts
+from common import constants
+from common import errors
 from common.appointment import Appointment
 from common.cryptographer import Cryptographer
 


### PR DESCRIPTION
binascii.{hexlify, unhexlify} are legacy functions that got built-ins in Python 3.5. Replacing all the instances.

The replacements are as follows:

`binascii.hexlify` --> `bytes.hex()`
`binascii.unhexlify` --> `bytes.from_hex()`

There are also some instances of `struck.pack` /  `struct.unpack` that were replaced for consistency:

`struct.pack(">I", x)` --> `x.to_bytes(4, 'big')`
`struct.unpack(">I", x)[0]` --> `int.from_bytes(x, 'big')`

Finally, the creation of `user_ids` in some tests have been simplified to use `Cryptographer.get_compressed_pk` instead duplicating code.