### PR TITLE
Distinguishes between appointment and extended_appointment

### DIFF
--- a/teos/builder.py
+++ b/teos/builder.py
@@ -30,14 +30,14 @@ class Builder:
         locator_uuid_map = {}
 
         for uuid, data in appointments_data.items():
-            appointment = ExtendedAppointment.from_dict(data)
-            appointments[uuid] = appointment.get_summary()
+            ext_appointment = ExtendedAppointment.from_dict(data)
+            appointments[uuid] = ext_appointment.get_summary()
 
-            if appointment.locator in locator_uuid_map:
-                locator_uuid_map[appointment.locator].append(uuid)
+            if ext_appointment.locator in locator_uuid_map:
+                locator_uuid_map[ext_appointment.locator].append(uuid)
 
             else:
-                locator_uuid_map[appointment.locator] = [uuid]
+                locator_uuid_map[ext_appointment.locator] = [uuid]
 
         return appointments, locator_uuid_map
 

--- a/teos/extended_appointment.py
+++ b/teos/extended_appointment.py
@@ -8,6 +8,9 @@ class ExtendedAppointment(Appointment):
     It extends the :class:`Appointment <common.appointment.Appointment>` with information relevant to the tower, such
     as the ``user_id``, ``user_signature`` and ``start_block``.
 
+    **All appointments are instances of** :obj:`Appointment <common.appointment.Appointment>` **on the user-side but**
+    :obj:`ExtendedAppointment` **on the tower-side.**
+
     Args:
         locator (:obj:`str`): A 16-byte hex-encoded value used by the tower to detect channel breaches. It serves as a
             trigger for the tower to decrypt and broadcast the penalty transaction.

--- a/teos/gatekeeper.py
+++ b/teos/gatekeeper.py
@@ -167,7 +167,7 @@ class Gatekeeper:
         except (InvalidParameter, InvalidKey, SignatureError):
             raise AuthenticationFailure("Wrong message or signature.")
 
-    def add_update_appointment(self, user_id, uuid, appointment):
+    def add_update_appointment(self, user_id, uuid, ext_appointment):
         """
         Adds (or updates) an appointment to a user subscription. The user slots are updated accordingly.
 
@@ -179,8 +179,8 @@ class Gatekeeper:
         Args:
             user_id (:obj:`str`): the public key that identifies the user (33-bytes hex str).
             uuid (:obj:`str`): the appointment uuid.
-            appointment (:obj:`ExtendedAppointment <teos.extended_appointment.ExtendedAppointment>`): the summary of new
-                appointment the user is requesting.
+            ext_appointment (:obj:`ExtendedAppointment <teos.extended_appointment.ExtendedAppointment>`): the summary of
+                new appointment the user is requesting.
 
         Returns:
             :obj:`int`: The number of remaining appointment slots.
@@ -198,7 +198,7 @@ class Gatekeeper:
             # For regular appointments 1 slot is reserved per ENCRYPTED_BLOB_MAX_SIZE_HEX block.
             used_slots = 0
 
-        required_slots = ceil(len(appointment.encrypted_blob) / ENCRYPTED_BLOB_MAX_SIZE_HEX)
+        required_slots = ceil(len(ext_appointment.encrypted_blob) / ENCRYPTED_BLOB_MAX_SIZE_HEX)
 
         if required_slots - used_slots <= self.registered_users.get(user_id).available_slots:
             # Filling / freeing slots depending on whether this is an update or not, and if it is bigger or smaller than

--- a/test/teos/unit/test_extended_appointment.py
+++ b/test/teos/unit/test_extended_appointment.py
@@ -9,7 +9,7 @@ from test.teos.unit.conftest import get_random_value_hex, generate_keypair
 
 # Parent methods are not tested.
 @pytest.fixture
-def appointment_data():
+def ext_appointment_data():
     sk, pk = generate_keypair()
     locator = get_random_value_hex(LOCATOR_LEN_BYTES)
     encrypted_blob_data = get_random_value_hex(100)
@@ -28,45 +28,45 @@ def appointment_data():
     }
 
 
-def test_init_appointment(appointment_data):
+def test_init_ext_appointment(ext_appointment_data):
     # The appointment has no checks whatsoever, since the inspector is the one taking care or that, and the only one
     # creating appointments.
-    appointment = ExtendedAppointment(
-        appointment_data["locator"],
-        appointment_data["encrypted_blob"],
-        appointment_data["to_self_delay"],
-        appointment_data["user_id"],
-        appointment_data["user_signature"],
-        appointment_data["start_block"],
+    ext_appointment = ExtendedAppointment(
+        ext_appointment_data["locator"],
+        ext_appointment_data["encrypted_blob"],
+        ext_appointment_data["to_self_delay"],
+        ext_appointment_data["user_id"],
+        ext_appointment_data["user_signature"],
+        ext_appointment_data["start_block"],
     )
 
     assert (
-        appointment_data["locator"] == appointment.locator
-        and appointment_data["to_self_delay"] == appointment.to_self_delay
-        and appointment_data["encrypted_blob"] == appointment.encrypted_blob
-        and appointment_data["user_id"] == appointment.user_id
-        and appointment_data["user_signature"] == appointment.user_signature
-        and appointment_data["start_block"] == appointment.start_block
+        ext_appointment_data["locator"] == ext_appointment.locator
+        and ext_appointment_data["to_self_delay"] == ext_appointment.to_self_delay
+        and ext_appointment_data["encrypted_blob"] == ext_appointment.encrypted_blob
+        and ext_appointment_data["user_id"] == ext_appointment.user_id
+        and ext_appointment_data["user_signature"] == ext_appointment.user_signature
+        and ext_appointment_data["start_block"] == ext_appointment.start_block
     )
 
 
-def test_get_summary(appointment_data):
-    assert ExtendedAppointment.from_dict(appointment_data).get_summary() == {
-        "locator": appointment_data["locator"],
-        "user_id": appointment_data["user_id"],
+def test_get_summary(ext_appointment_data):
+    assert ExtendedAppointment.from_dict(ext_appointment_data).get_summary() == {
+        "locator": ext_appointment_data["locator"],
+        "user_id": ext_appointment_data["user_id"],
     }
 
 
-def test_from_dict(appointment_data):
+def test_from_dict(ext_appointment_data):
     # The appointment should be build if we don't miss any field
-    appointment = ExtendedAppointment.from_dict(appointment_data)
-    assert isinstance(appointment, ExtendedAppointment)
+    ext_appointment = ExtendedAppointment.from_dict(ext_appointment_data)
+    assert isinstance(ext_appointment, ExtendedAppointment)
 
     # Otherwise it should fail
-    for key in appointment_data.keys():
-        prev_val = appointment_data[key]
-        appointment_data[key] = None
+    for key in ext_appointment_data.keys():
+        prev_val = ext_appointment_data[key]
+        ext_appointment_data[key] = None
 
         with pytest.raises(ValueError, match="Wrong appointment data"):
-            ExtendedAppointment.from_dict(appointment_data)
-            appointment_data[key] = prev_val
+            ExtendedAppointment.from_dict(ext_appointment_data)
+            ext_appointment_data[key] = prev_val


### PR DESCRIPTION
I've tried to do a better job distinguishing between `Appointment` and `ExtendedAppointment`.

I haven't changed the `Watcher`'s code much since I didn't want to change `self.appointments` to `self.extended_appointments`.

All appointments within the tower are extended anyway, whereas they are not on the user-side.