### PR TITLE
Avoid hardcoded strings

### DIFF
--- a/common/appointment.py
+++ b/common/appointment.py
@@ -1,4 +1,12 @@
-import struct
+from enum import Enum
+
+
+class AppointmentStatus(str, Enum):
+    """Represents all the possible states of an appointment in the system, or in a response to a client request."""
+
+    NOT_FOUND = "not_found"
+    BEING_WATCHED = "being_watched"
+    DISPUTE_RESPONDED = "dispute_responded"
 
 
 class Appointment:

--- a/contrib/client/test/test_teos_client.py
+++ b/contrib/client/test/test_teos_client.py
@@ -9,7 +9,7 @@ from requests.exceptions import ConnectionError
 
 import common.receipts as receipts
 from common.tools import compute_locator, is_compressed_pk
-from common.appointment import Appointment
+from common.appointment import Appointment, AppointmentStatus
 from common.cryptographer import Cryptographer
 from common.exceptions import InvalidParameter, InvalidKey, TowerResponseError
 
@@ -247,7 +247,7 @@ def test_get_appointment():
     # Response of get_appointment endpoint is an appointment with status added to it.
     response = {
         "locator": dummy_appointment_dict.get("locator"),
-        "status": "being_watched",
+        "status": AppointmentStatus.BEING_WATCHED,
         "appointment": dummy_appointment_dict,
     }
 

--- a/teos/internal_api.py
+++ b/teos/internal_api.py
@@ -4,7 +4,7 @@ from readerwriterlock import rwlock
 from google.protobuf.struct_pb2 import Struct
 
 from teos.logger import get_logger
-from common.appointment import Appointment
+from common.appointment import Appointment, AppointmentStatus
 from common.exceptions import InvalidParameter
 
 from teos.protobuf.appointment_pb2 import (
@@ -122,7 +122,7 @@ class _InternalAPI(TowerServicesServicer):
         with self.rw_lock.gen_rlock():
             try:
                 data, status = self.watcher.get_appointment(request.locator, request.signature)
-                if status == "being_watched":
+                if status == AppointmentStatus.BEING_WATCHED:
                     data = AppointmentData(
                         appointment=AppointmentProto(
                             locator=data.get("locator"),

--- a/teos/responder.py
+++ b/teos/responder.py
@@ -2,7 +2,7 @@ from queue import Queue
 from threading import Thread
 
 from teos.cleaner import Cleaner
-
+from teos.chain_monitor import ChainMonitor
 from teos.logger import get_logger
 from common.constants import IRREVOCABLY_RESOLVED
 
@@ -148,7 +148,7 @@ class Responder:
     def awake(self):
         """
             Starts a new thread to monitor the blockchain to make sure triggered appointments get enough depth.
-            The thread will run until the :obj:`ChainMonitor` adds the ``"END"`` message to the queue.
+            The thread will run until the :obj:`ChainMonitor` adds the ``ChainMonitor.END_MESSAGE`` to the queue.
 
             Returns:
                 :obj:`Thread <multithreading.Thread>`: The thread object that was just created and is already running.
@@ -273,8 +273,8 @@ class Responder:
         while True:
             block_hash = self.block_queue.get()
 
-            # When the ChainMonitor is stopped, a final "END" message is sent
-            if block_hash == "END":
+            # When the ChainMonitor is stopped, a final ChainMonitor.END_MESSAGE is sent
+            if block_hash == ChainMonitor.END_MESSAGE:
                 break
 
             block = self.block_processor.get_block(block_hash)

--- a/teos/watcher.py
+++ b/teos/watcher.py
@@ -5,11 +5,10 @@ from readerwriterlock import rwlock
 
 from teos.logger import get_logger
 import common.receipts as receipts
+from common.appointment import AppointmentStatus
 from common.tools import compute_locator
-from common.exceptions import BasicException
-from common.exceptions import EncryptionError
+from common.exceptions import BasicException, EncryptionError, InvalidParameter, SignatureError
 from common.cryptographer import Cryptographer, hash_160
-from common.exceptions import InvalidParameter, SignatureError
 
 from teos.cleaner import Cleaner
 from teos.extended_appointment import ExtendedAppointment
@@ -289,8 +288,8 @@ class Watcher:
             user_signature (:obj:`str`): the signature of the request by the user.
 
         Returns:
-            :obj:`tuple`: A tuple containing the appointment data and the status (either ``"being_watched"`` or
-            ``"dispute_responded"``).
+            :obj:`tuple`: A tuple containing the appointment data and the status, either
+                ``AppointmentStatus.BEING_WATCHED`` or ``AppointmentStatus.DISPUTE_RESPONDED``
 
         Raises:
             :obj:`AppointmentNotFound`: if the appointment is not found in the tower.
@@ -302,10 +301,10 @@ class Watcher:
 
         if uuid in self.appointments:
             appointment_data = self.db_manager.load_watcher_appointment(uuid)
-            status = "being_watched"
+            status = AppointmentStatus.BEING_WATCHED
         elif uuid in self.responder.trackers:
             appointment_data = self.db_manager.load_responder_tracker(uuid)
-            status = "dispute_responded"
+            status = AppointmentStatus.DISPUTE_RESPONDED
         else:
             raise AppointmentNotFound("Cannot find {}".format(locator))
 
@@ -661,7 +660,7 @@ class Watcher:
 
     def get_user_info(self, user_id):
         """
-        Returns the data hold by the tower about the user given an ``user_id``.
+        Returns the data held by the tower about the user given an ``user_id``.
 
         Args:
             user_id (:obj:`str`): the id of the requested user.

--- a/teos/watcher.py
+++ b/teos/watcher.py
@@ -11,6 +11,7 @@ from common.exceptions import BasicException, EncryptionError, InvalidParameter,
 from common.cryptographer import Cryptographer, hash_160
 
 from teos.cleaner import Cleaner
+from teos.chain_monitor import ChainMonitor
 from teos.extended_appointment import ExtendedAppointment
 from teos.block_processor import InvalidTransactionFormat
 
@@ -250,7 +251,7 @@ class Watcher:
     def awake(self):
         """
             Starts a new thread to monitor the blockchain for channel breaches. The thread will run until the
-            :obj:`ChainMonitor` adds the ``"END"`` message to the queue.
+            :obj:`ChainMonitor` adds ``ChainMonitor.END_MESSAGE`` to the queue.
 
             Returns:
                 :obj:`Thread <multithreading.Thread>`: The thread object that was just created and is already running.
@@ -451,8 +452,8 @@ class Watcher:
         while True:
             block_hash = self.block_queue.get()
 
-            # When the ChainMonitor is stopped, a final "END" message is sent
-            if block_hash == "END":
+            # When the ChainMonitor is stopped, a final ChainMonitor.END_MESSAGE message is sent
+            if block_hash == ChainMonitor.END_MESSAGE:
                 break
 
             block = self.block_processor.get_block(block_hash)

--- a/test/common/unit/test_appointment.py
+++ b/test/common/unit/test_appointment.py
@@ -1,4 +1,3 @@
-import struct
 import pytest
 
 from common.appointment import Appointment

--- a/test/teos/e2e/test_basic_e2e.py
+++ b/test/teos/e2e/test_basic_e2e.py
@@ -9,7 +9,7 @@ from contrib.client import teos_client
 import common.receipts as receipts
 from common.exceptions import TowerResponseError
 from common.tools import compute_locator
-from common.appointment import Appointment
+from common.appointment import Appointment, AppointmentStatus
 from common.cryptographer import Cryptographer
 
 from teos.cli.teos_cli import RPCClient
@@ -106,7 +106,7 @@ def test_appointment_life_cycle(run_bitcoind):
 
     # Get the information from the tower to check that it matches
     appointment_info = get_appointment_info(locator)
-    assert appointment_info.get("status") == "being_watched"
+    assert appointment_info.get("status") == AppointmentStatus.BEING_WATCHED
     assert appointment_info.get("locator") == locator
     assert appointment_info.get("appointment") == appointment.to_dict()
 
@@ -121,7 +121,7 @@ def test_appointment_life_cycle(run_bitcoind):
     # Trigger a breach and check again
     generate_block_with_transactions(commitment_tx)
     appointment_info = get_appointment_info(locator)
-    assert appointment_info.get("status") == "dispute_responded"
+    assert appointment_info.get("status") == AppointmentStatus.DISPUTE_RESPONDED
     assert appointment_info.get("locator") == locator
     appointments_in_watcher -= 1
     appointments_in_responder += 1
@@ -230,7 +230,7 @@ def test_appointment_malformed_penalty(run_bitcoind):
 
     # Get the information from the tower to check that it matches
     appointment_info = get_appointment_info(locator)
-    assert appointment_info.get("status") == "being_watched"
+    assert appointment_info.get("status") == AppointmentStatus.BEING_WATCHED
     assert appointment_info.get("locator") == locator
     assert appointment_info.get("appointment") == appointment.to_dict()
 
@@ -298,7 +298,7 @@ def test_two_identical_appointments(run_bitcoind):
     # The last appointment should have made it to the Responder
     appointment_info = get_appointment_info(locator)
 
-    assert appointment_info.get("status") == "dispute_responded"
+    assert appointment_info.get("status") == AppointmentStatus.DISPUTE_RESPONDED
     assert appointment_info.get("appointment").get("penalty_rawtx") == penalty_tx
 
 
@@ -325,9 +325,9 @@ def test_two_identical_appointments(run_bitcoind):
 #
 #     # Check that we can get it from both users
 #     appointment_info = get_appointment_info(locator)
-#     assert appointment_info.get("status") == "being_watched"
+#     assert appointment_info.get("status") == AppointmentStatus.BEING_WATCHED
 #     appointment_info = get_appointment_info(locator, sk=tmp_user_sk)
-#     assert appointment_info.get("status") == "being_watched"
+#     assert appointment_info.get("status") == AppointmentStatus.BEING_WATCHED
 #
 #     # Broadcast the commitment transaction and mine a block
 #     generate_block_with_transactions(commitment_tx)
@@ -344,7 +344,7 @@ def test_two_identical_appointments(run_bitcoind):
 #
 #     appointment_info = appointment_info if appointment_info is None else appointment_dup_info
 #
-#     assert appointment_info.get("status") == "dispute_responded"
+#     assert appointment_info.get("status") == AppointmentStatus.DISPUTE_RESPONDED
 #     assert appointment_info.get("appointment").get("penalty_rawtx") == penalty_tx
 
 
@@ -385,7 +385,7 @@ def test_two_appointment_same_locator_different_penalty_different_users(run_bitc
         appointment_info = appointment2_info
         appointment1_data = appointment2_data
 
-    assert appointment_info.get("status") == "dispute_responded"
+    assert appointment_info.get("status") == AppointmentStatus.DISPUTE_RESPONDED
     assert appointment_info.get("locator") == appointment1_data.get("locator")
     assert appointment_info.get("appointment").get("penalty_tx") == appointment1_data.get("penalty_tx")
 
@@ -402,7 +402,7 @@ def test_add_appointment_trigger_on_cache(run_bitcoind):
     # Send the data to the tower and request it back. It should have gone straightaway to the Responder
     appointment = teos_client.create_appointment(appointment_data)
     add_appointment(appointment)
-    assert get_appointment_info(locator).get("status") == "dispute_responded"
+    assert get_appointment_info(locator).get("status") == AppointmentStatus.DISPUTE_RESPONDED
 
 
 def test_add_appointment_invalid_trigger_on_cache(run_bitcoind):
@@ -483,7 +483,7 @@ def test_appointment_shutdown_teos_trigger_back_online(run_bitcoind):
     # Check that the appointment is still in the Watcher
     appointment_info = get_appointment_info(locator)
 
-    assert appointment_info.get("status") == "being_watched"
+    assert appointment_info.get("status") == AppointmentStatus.BEING_WATCHED
     assert appointment_info.get("appointment") == appointment.to_dict()
 
     # Trigger appointment after restart
@@ -491,7 +491,7 @@ def test_appointment_shutdown_teos_trigger_back_online(run_bitcoind):
 
     # The appointment should have been moved to the Responder
     appointment_info = get_appointment_info(locator)
-    assert appointment_info.get("status") == "dispute_responded"
+    assert appointment_info.get("status") == AppointmentStatus.DISPUTE_RESPONDED
 
 
 def test_appointment_shutdown_teos_trigger_while_offline(run_bitcoind):
@@ -509,7 +509,7 @@ def test_appointment_shutdown_teos_trigger_while_offline(run_bitcoind):
 
     # Check that the appointment is still in the Watcher
     appointment_info = get_appointment_info(locator)
-    assert appointment_info.get("status") == "being_watched"
+    assert appointment_info.get("status") == AppointmentStatus.BEING_WATCHED
     assert appointment_info.get("appointment") == appointment.to_dict()
 
     # Shutdown and trigger
@@ -525,4 +525,4 @@ def test_appointment_shutdown_teos_trigger_while_offline(run_bitcoind):
 
     # The appointment should have been moved to the Responder
     appointment_info = get_appointment_info(locator)
-    assert appointment_info.get("status") == "dispute_responded"
+    assert appointment_info.get("status") == AppointmentStatus.DISPUTE_RESPONDED

--- a/test/teos/unit/test_api.py
+++ b/test/teos/unit/test_api.py
@@ -8,7 +8,7 @@ from teos.watcher import Watcher
 from teos.inspector import Inspector
 from teos.gatekeeper import UserInfo
 from teos.internal_api import InternalAPI
-from common.appointment import Appointment
+from common.appointment import Appointment, AppointmentStatus
 from teos.appointments_dbm import AppointmentsDBM
 from teos.responder import Responder
 
@@ -468,7 +468,7 @@ def test_get_random_appointment_registered_user(client, user_sk=user_sk):
     # We should get a 404 not found since we are using a made up locator
     received_appointment = r.json
     assert r.status_code == HTTP_NOT_FOUND
-    assert received_appointment.get("status") == "not_found"
+    assert received_appointment.get("status") == AppointmentStatus.NOT_FOUND
 
 
 def test_get_appointment_not_registered_user(client):
@@ -499,7 +499,7 @@ def test_get_appointment_in_watcher(internal_api, client, appointment, monkeypat
     assert r.status_code == HTTP_OK
 
     # Check that the appointment is on the Watcher
-    assert r.json.get("status") == "being_watched"
+    assert r.json.get("status") == AppointmentStatus.BEING_WATCHED
 
     # Cast the extended appointment (used by the tower) to a regular appointment (used by the user)
     appointment = Appointment.from_dict(appointment.to_dict())
@@ -531,7 +531,7 @@ def test_get_appointment_in_responder(internal_api, client, generate_dummy_track
     assert r.status_code == HTTP_OK
 
     # Check that the appointment is on the Responder
-    assert r.json.get("status") == "dispute_responded"
+    assert r.json.get("status") == AppointmentStatus.DISPUTE_RESPONDED
 
     # Check the the sent appointment matches the received one
     assert tx_tracker.locator == r.json.get("locator")

--- a/test/teos/unit/test_chain_monitor.py
+++ b/test/teos/unit/test_chain_monitor.py
@@ -288,9 +288,10 @@ def test_terminate(block_processor):
     generate_blocks(1)
     time.sleep(0.11)  # wait longer than the polling_delta
 
-    # there should be only the "END" message in the receiving queue, as the new block was generated after terminating
+    # there should be only the ChainMonitor.END_MESSAGE message in the receiving queue, as the new block was generated
+    # after terminating
     assert queue.qsize() == 1
-    assert queue.get() == "END"
+    assert queue.get() == ChainMonitor.END_MESSAGE
 
 
 @pytest.mark.timeout(5)

--- a/watchtower-plugin/test_watchtower.py
+++ b/watchtower-plugin/test_watchtower.py
@@ -12,9 +12,8 @@ from flask import Flask, request, jsonify
 from pyln.testing.fixtures import *  # noqa: F401,F403
 
 import common.receipts as receipts
-from common import constants
-from common import errors
-from common.appointment import Appointment
+from common import constants, errors
+from common.appointment import Appointment, AppointmentStatus
 from common.cryptographer import Cryptographer
 
 plugin_path = os.path.join(os.path.dirname(__file__), "watchtower.py")
@@ -100,11 +99,11 @@ class TowerMock:
         ):
             rcode = constants.HTTP_OK
             response = self.users[user_id]["appointments"][locator]
-            response["status"] = "being_watched"
+            response["status"] = AppointmentStatus.BEING_WATCHED
 
         else:
             rcode = constants.HTTP_NOT_FOUND
-            response = {"locator": locator, "status": "not_found"}
+            response = {"locator": locator, "status": AppointmentStatus.NOT_FOUND}
 
         return jsonify(response), rcode
 
@@ -421,10 +420,10 @@ def test_get_appointment(node_factory):
     for locator in local_appointments:
         response = l2.rpc.getappointment(tower_id, locator)
         assert response.get("locator") == locator
-        assert response.get("status") == "being_watched"
+        assert response.get("status") == AppointmentStatus.BEING_WATCHED
 
     # Made up appointments should return a 404
     rand_locator = get_random_value_hex(16)
     response = l2.rpc.getappointment(tower_id, rand_locator)
     assert response.get("locator") == rand_locator
-    assert response.get("status") == "not_found"
+    assert response.get("status") == AppointmentStatus.NOT_FOUND

--- a/watchtower-plugin/tower_info.py
+++ b/watchtower-plugin/tower_info.py
@@ -1,6 +1,6 @@
 class TowerInfo:
     """
-    TowerInfo represents all the data the plugin hold about a tower.
+    TowerInfo represents all the data the plugin holds about a tower.
 
     Args:
         netaddr (:obj:`str`): the tower network address.


### PR DESCRIPTION
Adds an AppointmentStatus Enum for the possible appointment statuses, and a class constant for the "END" message of the ChainMonitor.

A larger refactoring in the same spirit could make sense for the config dictionary keys, but it is not trivial because of the need of making it work with `config_loader.py`.

Also fixing a few documentation errors and typos

Closes: 173