### PR TITLE
Handles request rejection for expired subscriptions

### DIFF
--- a/teos/api.py
+++ b/teos/api.py
@@ -301,8 +301,15 @@ class API:
                 ),
             }
 
-        except (InspectionFailed, grpc.RpcError):
-            rcode = HTTP_NOT_FOUND
-            response = {"locator": locator, "status": AppointmentStatus.NOT_FOUND}
+        except (InspectionFailed, grpc.RpcError) as e:
+            if isinstance(e, grpc.RpcError) and e.code() == grpc.StatusCode.UNAUTHENTICATED:
+                rcode = HTTP_BAD_REQUEST
+                response = {
+                    "error": e.details(),
+                    "error_code": errors.APPOINTMENT_INVALID_SIGNATURE_OR_INSUFFICIENT_SLOTS,
+                }
+            else:
+                rcode = HTTP_NOT_FOUND
+                response = {"locator": locator, "status": AppointmentStatus.NOT_FOUND}
 
         return jsonify(response), rcode

--- a/teos/constants.py
+++ b/teos/constants.py
@@ -1,8 +1,5 @@
 import logging.handlers
 
-
-# the grace time in seconds to complete any pending call when stopping one of the services of TEOS
-SHUTDOWN_GRACE_TIME = 10
-
-# The port used for the tcp logging service is 9020
-TCP_LOGGING_PORT = logging.handlers.DEFAULT_TCP_LOGGING_PORT
+SHUTDOWN_GRACE_TIME = 10  # Grace time in seconds to complete any pending call when stopping one of the services of TEOS
+TCP_LOGGING_PORT = logging.handlers.DEFAULT_TCP_LOGGING_PORT  # The port used for the tcp logging service is 9020
+OUTDATED_USERS_CACHE_SIZE_BLOCKS = 10  # Size of the users cache, in blocks

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -135,7 +135,9 @@ class TeosDaemon:
 
         # Create the chain monitor
         self.chain_monitor = ChainMonitor(
-            [self.watcher.block_queue, self.watcher.responder.block_queue], self.block_processor, bitcoind_feed_params
+            [self.watcher.block_queue, responder.block_queue, gatekeeper.block_queue],
+            self.block_processor,
+            bitcoind_feed_params,
         )
 
         # Set up the internal API


### PR DESCRIPTION
Expired subscriptions were not being checked when data was being sent by / requested from the tower. This PR handled that case and also moves the `UserInfo` deletion to the `Gatekeeper` instead of it being handled by either the `Watcher` or the `Responder`.

For this changes to work, the `Gatekeeper` now needs to have a notion of time, which is given by making him subscribe to the `ChainMonitor`. Also, data is being deleted with a `USERS_CACHE_SIZE_BLOCKS` delay so both the `Watcher` and the `Responder` can query any user related data they may need in order to do their own cleanups.