### PR TITLE
Updates and old error type left after #239 was merged

### DIFF
--- a/teos/api.py
+++ b/teos/api.py
@@ -307,7 +307,7 @@ class API:
                 rcode = HTTP_BAD_REQUEST
                 response = {
                     "error": e.details(),
-                    "error_code": errors.APPOINTMENT_INVALID_SIGNATURE_OR_INSUFFICIENT_SLOTS,
+                    "error_code": errors.APPOINTMENT_INVALID_SIGNATURE_OR_SUBSCRIPTION_ERROR,
                 }
             else:
                 rcode = HTTP_NOT_FOUND


### PR DESCRIPTION
One instance of `APPOINTMENT_INVALID_SIGNATURE_OR_INSUFFICIENT_SLOTS` was left after #239.