### PR TITLE
Reworks teos to use RWLocks

### DIFF
--- a/teos/internal_api.py
+++ b/teos/internal_api.py
@@ -1,6 +1,5 @@
 import grpc
 from concurrent import futures
-from readerwriterlock import rwlock
 from google.protobuf.struct_pb2 import Struct
 
 from teos.logger import get_logger
@@ -61,135 +60,125 @@ class _InternalAPI(TowerServicesServicer):
             the main backend class of the tower and can interact with the rest.
         stop_command_event (:obj:`multiprocessing.Event`): an Event to be set when a `stop` command is issued.
         logger (:obj:`Logger <teos.logger.Logger>`): the logger for this component.
-
-    Attributes:
-        rw_lock (:obj:`RWLockWrite <rwlock.RWLockWrite>`): a reader-writer lock to manage concurrent access to the
-            backend.
     """
 
     def __init__(self, watcher, stop_command_event, logger):
         self.watcher = watcher
         self.stop_command_event = stop_command_event
         self.logger = logger
-        self.rw_lock = rwlock.RWLockWrite()  # lock to be acquired before interacting with the watchtower's state
 
     def register(self, request, context):
         """Registers a user to the tower."""
-        with self.rw_lock.gen_wlock():
-            try:
-                available_slots, subscription_expiry, subscription_signature = self.watcher.register(request.user_id)
+        try:
+            available_slots, subscription_expiry, subscription_signature = self.watcher.register(request.user_id)
 
-                return RegisterResponse(
-                    user_id=request.user_id,
-                    available_slots=available_slots,
-                    subscription_expiry=subscription_expiry,
-                    subscription_signature=subscription_signature,
-                )
+            return RegisterResponse(
+                user_id=request.user_id,
+                available_slots=available_slots,
+                subscription_expiry=subscription_expiry,
+                subscription_signature=subscription_signature,
+            )
 
-            except InvalidParameter as e:
-                context.set_details(e.msg)
-                context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
-                return RegisterResponse()
+        except InvalidParameter as e:
+            context.set_details(e.msg)
+            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+            return RegisterResponse()
 
     def add_appointment(self, request, context):
         """Processes the request to add an appointment from a user."""
-        with self.rw_lock.gen_wlock():
-            try:
-                appointment = Appointment(
-                    request.appointment.locator, request.appointment.encrypted_blob, request.appointment.to_self_delay
-                )
-                return AddAppointmentResponse(**self.watcher.add_appointment(appointment, request.signature))
+        try:
+            appointment = Appointment(
+                request.appointment.locator, request.appointment.encrypted_blob, request.appointment.to_self_delay
+            )
+            return AddAppointmentResponse(**self.watcher.add_appointment(appointment, request.signature))
 
-            except (AuthenticationFailure, NotEnoughSlots):
-                msg = "Invalid signature or user does not have enough slots available"
-                status_code = grpc.StatusCode.UNAUTHENTICATED
+        except (AuthenticationFailure, NotEnoughSlots):
+            msg = "Invalid signature or user does not have enough slots available"
+            status_code = grpc.StatusCode.UNAUTHENTICATED
 
-            except AppointmentLimitReached:
-                msg = "Appointment limit reached"
-                status_code = grpc.StatusCode.RESOURCE_EXHAUSTED
+        except AppointmentLimitReached:
+            msg = "Appointment limit reached"
+            status_code = grpc.StatusCode.RESOURCE_EXHAUSTED
 
-            except SubscriptionExpired as e:
-                msg = str(e)
-                status_code = grpc.StatusCode.UNAUTHENTICATED
+        except SubscriptionExpired as e:
+            msg = str(e)
+            status_code = grpc.StatusCode.UNAUTHENTICATED
 
-            except AppointmentAlreadyTriggered:
-                msg = "The provided appointment has already been triggered"
-                status_code = grpc.StatusCode.ALREADY_EXISTS
+        except AppointmentAlreadyTriggered:
+            msg = "The provided appointment has already been triggered"
+            status_code = grpc.StatusCode.ALREADY_EXISTS
 
-            context.set_details(msg)
-            context.set_code(status_code)
+        context.set_details(msg)
+        context.set_code(status_code)
 
-            return AddAppointmentResponse()
+        return AddAppointmentResponse()
 
     def get_appointment(self, request, context):
         """Returns an appointment stored in the tower, if it exists."""
-        with self.rw_lock.gen_rlock():
-            try:
-                data, status = self.watcher.get_appointment(request.locator, request.signature)
-                if status == AppointmentStatus.BEING_WATCHED:
-                    data = AppointmentData(
-                        appointment=AppointmentProto(
-                            locator=data.get("locator"),
-                            encrypted_blob=data.get("encrypted_blob"),
-                            to_self_delay=data.get("to_self_delay"),
-                        )
+        try:
+            data, status = self.watcher.get_appointment(request.locator, request.signature)
+            if status == AppointmentStatus.BEING_WATCHED:
+                data = AppointmentData(
+                    appointment=AppointmentProto(
+                        locator=data.get("locator"),
+                        encrypted_blob=data.get("encrypted_blob"),
+                        to_self_delay=data.get("to_self_delay"),
                     )
-                else:
-                    data = AppointmentData(
-                        tracker=TrackerProto(
-                            locator=data.get("locator"),
-                            dispute_txid=data.get("dispute_txid"),
-                            penalty_txid=data.get("penalty_txid"),
-                            penalty_rawtx=data.get("penalty_rawtx"),
-                        )
+                )
+            else:
+                data = AppointmentData(
+                    tracker=TrackerProto(
+                        locator=data.get("locator"),
+                        dispute_txid=data.get("dispute_txid"),
+                        penalty_txid=data.get("penalty_txid"),
+                        penalty_rawtx=data.get("penalty_rawtx"),
                     )
-                return GetAppointmentResponse(appointment_data=data, status=status)
+                )
+            return GetAppointmentResponse(appointment_data=data, status=status)
 
-            except (AuthenticationFailure, AppointmentNotFound):
-                msg = "Appointment not found"
-                status_code = grpc.StatusCode.NOT_FOUND
+        except (AuthenticationFailure, AppointmentNotFound):
+            msg = "Appointment not found"
+            status_code = grpc.StatusCode.NOT_FOUND
 
-            except SubscriptionExpired as e:
-                msg = str(e)
-                status_code = grpc.StatusCode.UNAUTHENTICATED
+        except SubscriptionExpired as e:
+            msg = str(e)
+            status_code = grpc.StatusCode.UNAUTHENTICATED
 
-            context.set_details(msg)
-            context.set_code(status_code)
+        context.set_details(msg)
+        context.set_code(status_code)
 
-            return GetAppointmentResponse()
+        return GetAppointmentResponse()
 
     def get_subscription_info(self, request, context):
         """Returns a user's subscription information stored in the tower, if the user is registered."""
-        with self.rw_lock.gen_rlock():
-            try:
-                subscription_info = self.watcher.get_subscription_info(request.signature)
+        try:
+            subscription_info, locators = self.watcher.get_subscription_info(request.signature)
 
-                user_struct = Struct()
-                user_struct.update(
-                    {
-                        "subscription_expiry": subscription_info.subscription_expiry,
-                        "available_slots": subscription_info.available_slots,
-                        "appointments": subscription_info.locators,
-                    }
-                )
-                return GetUserResponse(user=user_struct)
+            user_struct = Struct()
+            user_struct.update(
+                {
+                    "subscription_expiry": subscription_info.subscription_expiry,
+                    "available_slots": subscription_info.available_slots,
+                    "appointments": locators,
+                }
+            )
+            return GetUserResponse(user=user_struct)
 
-            except AuthenticationFailure:
-                msg = "User not found. Have you registered?"
+        except AuthenticationFailure:
+            msg = "User not found. Have you registered?"
 
-            except SubscriptionExpired as e:
-                msg = str(e)
+        except SubscriptionExpired as e:
+            msg = str(e)
 
-            context.set_details(msg)
-            context.set_code(grpc.StatusCode.UNAUTHENTICATED)
+        context.set_details(msg)
+        context.set_code(grpc.StatusCode.UNAUTHENTICATED)
 
-            return GetUserResponse()
+        return GetUserResponse()
 
     def get_all_appointments(self, request, context):
         """Returns all the appointments in the tower."""
-        with self.rw_lock.gen_rlock():
-            watcher_appointments = self.watcher.get_all_watcher_appointments()
-            responder_trackers = self.watcher.get_all_responder_trackers()
+        watcher_appointments = self.watcher.get_all_watcher_appointments()
+        responder_trackers = self.watcher.get_all_responder_trackers()
 
         appointments = Struct()
         appointments.update({"watcher_appointments": watcher_appointments, "responder_trackers": responder_trackers})
@@ -198,38 +187,35 @@ class _InternalAPI(TowerServicesServicer):
 
     def get_tower_info(self, request, context):
         """Returns generic information about the tower."""
-        with self.rw_lock.gen_rlock():
-            return GetTowerInfoResponse(
-                tower_id=self.watcher.tower_id,
-                n_registered_users=self.watcher.n_registered_users,
-                n_watcher_appointments=self.watcher.n_watcher_appointments,
-                n_responder_trackers=self.watcher.n_responder_trackers,
-            )
+        return GetTowerInfoResponse(
+            tower_id=self.watcher.tower_id,
+            n_registered_users=self.watcher.n_registered_users,
+            n_watcher_appointments=self.watcher.n_watcher_appointments,
+            n_responder_trackers=self.watcher.n_responder_trackers,
+        )
 
     def get_users(self, request, context):
         """Returns the list of all registered user ids."""
-        with self.rw_lock.gen_rlock():
-            return GetUsersResponse(user_ids=self.watcher.get_registered_user_ids())
+        return GetUsersResponse(user_ids=self.watcher.get_registered_user_ids())
 
     def get_user(self, request, context):
         """Returns information about a user, given its user id."""
-        with self.rw_lock.gen_rlock():
-            user_info = self.watcher.get_user_info(request.user_id)
+        user_info = self.watcher.get_user_info(request.user_id)
 
-            if not user_info:
-                context.set_details("User not found")
-                context.set_code(grpc.StatusCode.NOT_FOUND)
-                return GetUserResponse()
+        if not user_info:
+            context.set_details("User not found")
+            context.set_code(grpc.StatusCode.NOT_FOUND)
+            return GetUserResponse()
 
-            user_struct = Struct()
-            user_struct.update(
-                {
-                    "subscription_expiry": user_info.subscription_expiry,
-                    "available_slots": user_info.available_slots,
-                    "appointments": list(user_info.appointments.keys()),
-                }
-            )
-            return GetUserResponse(user=user_struct)
+        user_struct = Struct()
+        user_struct.update(
+            {
+                "subscription_expiry": user_info.subscription_expiry,
+                "available_slots": user_info.available_slots,
+                "appointments": list(user_info.appointments.keys()),
+            }
+        )
+        return GetUserResponse(user=user_struct)
 
     def stop(self, request, context):
         """Initiates a graceful shutdown of the tower."""

--- a/teos/responder.py
+++ b/teos/responder.py
@@ -1,5 +1,6 @@
 from queue import Queue
 from threading import Thread
+from readerwriterlock import rwlock
 
 from teos.cleaner import Cleaner
 from teos.chain_monitor import ChainMonitor
@@ -144,6 +145,7 @@ class Responder:
         self.carrier = carrier
         self.block_processor = block_processor
         self.last_known_block = db_manager.load_last_block_hash_responder()
+        self.rw_lock = rwlock.RWLockWrite()
 
     def awake(self):
         """
@@ -239,23 +241,24 @@ class Responder:
         """
 
         tracker = TransactionTracker(locator, dispute_txid, penalty_txid, penalty_rawtx, user_id)
+        with self.rw_lock.gen_wlock():
+            # We only store the penalty_txid, locator and user_id in memory. The rest is dumped into the db.
+            self.trackers[uuid] = tracker.get_summary()
 
-        # We only store the penalty_txid, locator and user_id in memory. The rest is dumped into the db.
-        self.trackers[uuid] = tracker.get_summary()
+            if penalty_txid in self.tx_tracker_map:
+                self.tx_tracker_map[penalty_txid].append(uuid)
 
-        if penalty_txid in self.tx_tracker_map:
-            self.tx_tracker_map[penalty_txid].append(uuid)
+            else:
+                self.tx_tracker_map[penalty_txid] = [uuid]
 
-        else:
-            self.tx_tracker_map[penalty_txid] = [uuid]
+            # In the case we receive two trackers with the same penalty txid we only add it to the unconfirmed txs list
+            # once
+            if penalty_txid not in self.unconfirmed_txs and confirmations == 0:
+                self.unconfirmed_txs.append(penalty_txid)
 
-        # In the case we receive two trackers with the same penalty txid we only add it to the unconfirmed txs list once
-        if penalty_txid not in self.unconfirmed_txs and confirmations == 0:
-            self.unconfirmed_txs.append(penalty_txid)
+            self.db_manager.store_responder_tracker(uuid, tracker.to_dict())
 
-        self.db_manager.store_responder_tracker(uuid, tracker.to_dict())
-
-        self.logger.info("New tracker added", dispute_txid=dispute_txid, penalty_txid=penalty_txid, user_id=user_id)
+            self.logger.info("New tracker added", dispute_txid=dispute_txid, penalty_txid=penalty_txid, user_id=user_id)
 
     def do_watch(self):
         """
@@ -286,32 +289,30 @@ class Responder:
                 txids = block.get("tx")
 
                 if self.last_known_block == block.get("previousblockhash"):
-                    completed_trackers = self.get_completed_trackers()
-                    outdated_trackers = self.get_outdated_trackers(block.get("height"))
-                    trackers_to_delete_gatekeeper = {
-                        uuid: self.trackers[uuid].get("user_id") for uuid in completed_trackers
-                    }
+                    with self.rw_lock.gen_wlock():
+                        completed_trackers = self.get_completed_trackers()
+                        outdated_trackers = self.get_outdated_trackers(block.get("height"))
+                        trackers_to_delete_gatekeeper = {
+                            uuid: self.trackers[uuid].get("user_id") for uuid in completed_trackers
+                        }
 
-                    self.check_confirmations(txids)
+                        self.check_confirmations(txids)
 
-                    Cleaner.delete_trackers(
-                        completed_trackers, block.get("height"), self.trackers, self.tx_tracker_map, self.db_manager
-                    )
-                    Cleaner.delete_trackers(
-                        outdated_trackers,
-                        block.get("height"),
-                        self.trackers,
-                        self.tx_tracker_map,
-                        self.db_manager,
-                        outdated=True,
-                    )
-                    # Remove completed trackers from the gatekeeper.
-                    with self.gatekeeper.lock:
-                        Cleaner.delete_gatekeeper_appointments(
-                            trackers_to_delete_gatekeeper, self.gatekeeper.registered_users, self.gatekeeper.user_db
+                        Cleaner.delete_trackers(
+                            completed_trackers, block.get("height"), self.trackers, self.tx_tracker_map, self.db_manager
                         )
+                        Cleaner.delete_trackers(
+                            outdated_trackers,
+                            block.get("height"),
+                            self.trackers,
+                            self.tx_tracker_map,
+                            self.db_manager,
+                            outdated=True,
+                        )
+                        # Remove completed trackers from the Gatekeeper
+                        self.gatekeeper.delete_appointments(trackers_to_delete_gatekeeper)
 
-                    self.rebroadcast(self.get_txs_to_rebroadcast())
+                        self.rebroadcast(self.get_txs_to_rebroadcast())
 
                 # NOTCOVERED
                 else:
@@ -500,15 +501,16 @@ class Responder:
                 penalty_tx = self.carrier.get_transaction(tracker.penalty_txid)
 
                 if penalty_tx is not None:
-                    # If the penalty exists we need to check is it's on the blockchain or not so we can update the
-                    # unconfirmed transactions list accordingly.
-                    if penalty_tx.get("confirmations") is None:
-                        self.unconfirmed_txs.append(tracker.penalty_txid)
+                    with self.rw_lock.gen_wlock():
+                        # If the penalty exists we need to check is it's on the blockchain or not so we can update the
+                        # unconfirmed transactions list accordingly.
+                        if penalty_tx.get("confirmations") is None:
+                            self.unconfirmed_txs.append(tracker.penalty_txid)
 
-                        self.logger.info(
-                            "Penalty transaction back in mempool. Updating unconfirmed transactions",
-                            penalty_txid=tracker.penalty_txid,
-                        )
+                            self.logger.info(
+                                "Penalty transaction back in mempool. Updating unconfirmed transactions",
+                                penalty_txid=tracker.penalty_txid,
+                            )
 
                 else:
                     # If the penalty transaction is missing, we need to reset the tracker.

--- a/teos/watcher.py
+++ b/teos/watcher.py
@@ -98,8 +98,7 @@ class LocatorCache:
         """
 
         with self.rw_lock.gen_rlock():
-            locator = self.cache.get(locator)
-        return locator
+            return self.cache.get(locator)
 
     def update(self, block_hash, locator_txid_map):
         """
@@ -228,6 +227,7 @@ class Watcher:
         self.signing_key = sk
         self.last_known_block = db_manager.load_last_block_hash_watcher()
         self.locator_cache = LocatorCache(blocks_in_cache)
+        self.rw_lock = rwlock.RWLockWrite()
 
     @property
     def tower_id(self):
@@ -237,17 +237,20 @@ class Watcher:
     @property
     def n_registered_users(self):
         """Get the number of users currently registered to the tower."""
-        return len(self.gatekeeper.registered_users)
+        with self.gatekeeper.rw_lock.gen_rlock():
+            return len(self.gatekeeper.registered_users)
 
     @property
     def n_watcher_appointments(self):
         """Get the total number of appointments stored in the watcher."""
-        return len(self.appointments)
+        with self.rw_lock.gen_rlock():
+            return len(self.appointments)
 
     @property
     def n_responder_trackers(self):
         """Get the total number of trackers in the responder."""
-        return len(self.responder.trackers)
+        with self.responder.rw_lock.gen_rlock():
+            return len(self.responder.trackers)
 
     def awake(self):
         """
@@ -300,22 +303,24 @@ class Watcher:
 
         message = "get appointment {}".format(locator).encode("utf-8")
         user_id = self.gatekeeper.authenticate_user(message, user_signature)
-        if self.gatekeeper.has_subscription_expired(user_id):
-            raise SubscriptionExpired(
-                f"Your subscription expired at block {self.gatekeeper.registered_users[user_id].subscription_expiry}"
-            )
+        has_expired, expiry = self.gatekeeper.has_subscription_expired(user_id)
+        if has_expired:
+            raise SubscriptionExpired(f"Your subscription expired at block {expiry}")
+
         uuid = hash_160("{}{}".format(locator, user_id))
 
-        if uuid in self.appointments:
-            appointment_data = self.db_manager.load_watcher_appointment(uuid)
-            status = AppointmentStatus.BEING_WATCHED
-        elif uuid in self.responder.trackers:
-            appointment_data = self.db_manager.load_responder_tracker(uuid)
-            status = AppointmentStatus.DISPUTE_RESPONDED
-        else:
-            raise AppointmentNotFound("Cannot find {}".format(locator))
+        with self.rw_lock.gen_rlock():
+            with self.responder.rw_lock.gen_rlock():
+                if uuid in self.appointments:
+                    appointment_data = self.db_manager.load_watcher_appointment(uuid)
+                    status = AppointmentStatus.BEING_WATCHED
+                elif uuid in self.responder.trackers:
+                    appointment_data = self.db_manager.load_responder_tracker(uuid)
+                    status = AppointmentStatus.DISPUTE_RESPONDED
+                else:
+                    raise AppointmentNotFound("Cannot find {}".format(locator))
 
-        return appointment_data, status
+                return appointment_data, status
 
     def add_appointment(self, appointment, user_signature):
         """
@@ -344,105 +349,107 @@ class Watcher:
         Raises:
             :obj:`AppointmentLimitReached`: If the tower cannot hold more appointments (cap reached).
             :obj:`AuthenticationFailure`: If the user cannot be authenticated.
-            :obj:`NotEnoughSlots`: If the user does not have enough available slots, so the appointment is rejected.\
+            :obj:`NotEnoughSlots`: If the user does not have enough available slots, so the appointment is rejected.
             :obj:`SubscriptionExpired`: If the user subscription has expired.
         """
 
-        if len(self.appointments) >= self.max_appointments:
-            message = "Maximum appointments reached, appointment rejected"
-            self.logger.info(message, locator=appointment.locator)
-            raise AppointmentLimitReached(message)
+        with self.rw_lock.gen_wlock():
+            if len(self.appointments) >= self.max_appointments:
+                message = "Maximum appointments reached, appointment rejected"
+                self.logger.info(message, locator=appointment.locator)
+                raise AppointmentLimitReached(message)
 
-        user_id = self.gatekeeper.authenticate_user(appointment.serialize(), user_signature)
-        if self.gatekeeper.has_subscription_expired(user_id):
-            raise SubscriptionExpired(
-                f"Your subscription expired at block {self.gatekeeper.registered_users[user_id].subscription_expiry}"
+            user_id = self.gatekeeper.authenticate_user(appointment.serialize(), user_signature)
+            has_subscription_expired, expiry = self.gatekeeper.has_subscription_expired(user_id)
+            if has_subscription_expired:
+                raise SubscriptionExpired(f"Your subscription expired at block {expiry}")
+
+            start_block = self.block_processor.get_block(self.last_known_block).get("height")
+            extended_appointment = ExtendedAppointment(
+                appointment.locator,
+                appointment.encrypted_blob,
+                appointment.to_self_delay,
+                user_id,
+                user_signature,
+                start_block,
             )
-        start_block = self.block_processor.get_block(self.last_known_block).get("height")
-        extended_appointment = ExtendedAppointment(
-            appointment.locator,
-            appointment.encrypted_blob,
-            appointment.to_self_delay,
-            user_id,
-            user_signature,
-            start_block,
-        )
 
-        # The uuids are generated as the RIPEMD160(locator||user_pubkey).
-        # If an appointment is requested by the user the uuid can be recomputed and queried straightaway (no maps).
-        uuid = hash_160("{}{}".format(extended_appointment.locator, user_id))
+            # The uuids are generated as the RIPEMD160(locator||user_pubkey).
+            # If an appointment is requested by the user the uuid can be recomputed and queried straightaway (no maps).
+            uuid = hash_160("{}{}".format(extended_appointment.locator, user_id))
 
-        # If this is a copy of an appointment we've already reacted to, the new appointment is rejected.
-        if uuid in self.responder.trackers:
-            message = "Appointment already in Responder"
-            self.logger.info(message)
-            raise AppointmentAlreadyTriggered(message)
+            # If this is a copy of an appointment we've already reacted to, the new appointment is rejected.
+            with self.responder.rw_lock.gen_rlock():
+                if uuid in self.responder.trackers:
+                    message = "Appointment already in Responder"
+                    self.logger.info(message)
+                    raise AppointmentAlreadyTriggered(message)
 
-        # Add the appointment to the Gatekeeper
-        available_slots = self.gatekeeper.add_update_appointment(user_id, uuid, extended_appointment)
+            # Add the appointment to the Gatekeeper
+            available_slots = self.gatekeeper.add_update_appointment(user_id, uuid, extended_appointment)
 
-        # Appointments that were triggered in blocks held in the cache
-        dispute_txid = self.locator_cache.get_txid(extended_appointment.locator)
-        if dispute_txid:
+            # Appointments that were triggered in blocks held in the cache
+            dispute_txid = self.locator_cache.get_txid(extended_appointment.locator)
+            if dispute_txid:
+                try:
+                    penalty_txid, penalty_rawtx = self.check_breach(uuid, extended_appointment, dispute_txid)
+                    receipt = self.responder.handle_breach(
+                        uuid,
+                        extended_appointment.locator,
+                        dispute_txid,
+                        penalty_txid,
+                        penalty_rawtx,
+                        user_id,
+                        self.last_known_block,
+                    )
+
+                    # At this point the appointment is accepted but data is only kept if it goes through the Responder.
+                    # Otherwise it is dropped.
+                    if receipt.delivered:
+                        self.db_manager.store_watcher_appointment(uuid, extended_appointment.to_dict())
+                        self.db_manager.create_append_locator_map(extended_appointment.locator, uuid)
+                        self.db_manager.create_triggered_appointment_flag(uuid)
+
+                except (EncryptionError, InvalidTransactionFormat):
+                    # If data inside the encrypted blob is invalid, the appointment is accepted but the data is dropped.
+                    # (same as with data that bounces in the Responder). This reduces the appointment slot count so it
+                    # could be used to discourage user misbehaviour.
+                    pass
+
+            # Regular appointments that have not been triggered (or, at least, not recently)
+            else:
+                self.appointments[uuid] = extended_appointment.get_summary()
+
+                if extended_appointment.locator in self.locator_uuid_map:
+                    # If the uuid is already in the map it means this is an update.
+                    if uuid not in self.locator_uuid_map[extended_appointment.locator]:
+                        self.locator_uuid_map[extended_appointment.locator].append(uuid)
+                else:
+                    # Otherwise two users have sent an appointment with the same locator, so we need to store both.
+                    self.locator_uuid_map[extended_appointment.locator] = [uuid]
+
+                self.db_manager.store_watcher_appointment(uuid, extended_appointment.to_dict())
+                self.db_manager.create_append_locator_map(extended_appointment.locator, uuid)
+
             try:
-                penalty_txid, penalty_rawtx = self.check_breach(uuid, extended_appointment, dispute_txid)
-                receipt = self.responder.handle_breach(
-                    uuid,
-                    extended_appointment.locator,
-                    dispute_txid,
-                    penalty_txid,
-                    penalty_rawtx,
-                    user_id,
-                    self.last_known_block,
+                signature = Cryptographer.sign(
+                    receipts.create_appointment_receipt(user_signature, start_block), self.signing_key
                 )
 
-                # At this point the appointment is accepted but data is only kept if it goes through the Responder.
-                # Otherwise it is dropped.
-                if receipt.delivered:
-                    self.db_manager.store_watcher_appointment(uuid, extended_appointment.to_dict())
-                    self.db_manager.create_append_locator_map(extended_appointment.locator, uuid)
-                    self.db_manager.create_triggered_appointment_flag(uuid)
+            except (InvalidParameter, SignatureError):
+                # This should never happen since data is sanitized, just in case to avoid a crash
+                self.logger.error("Data couldn't be signed", appointment=extended_appointment.to_dict())
+                signature = None
 
-            except (EncryptionError, InvalidTransactionFormat):
-                # If data inside the encrypted blob is invalid, the appointment is accepted but the data is dropped.
-                # (same as with data that bounces in the Responder). This reduces the appointment slot count so it
-                # could be used to discourage user misbehaviour.
-                pass
+            self.logger.info("New appointment accepted", locator=extended_appointment.locator)
 
-        # Regular appointments that have not been triggered (or, at least, not recently)
-        else:
-            self.appointments[uuid] = extended_appointment.get_summary()
-
-            if extended_appointment.locator in self.locator_uuid_map:
-                # If the uuid is already in the map it means this is an update.
-                if uuid not in self.locator_uuid_map[extended_appointment.locator]:
-                    self.locator_uuid_map[extended_appointment.locator].append(uuid)
-            else:
-                # Otherwise two users have sent an appointment with the same locator, so we need to store both.
-                self.locator_uuid_map[extended_appointment.locator] = [uuid]
-
-            self.db_manager.store_watcher_appointment(uuid, extended_appointment.to_dict())
-            self.db_manager.create_append_locator_map(extended_appointment.locator, uuid)
-
-        try:
-            signature = Cryptographer.sign(
-                receipts.create_appointment_receipt(user_signature, start_block), self.signing_key
-            )
-
-        except (InvalidParameter, SignatureError):
-            # This should never happen since data is sanitized, just in case to avoid a crash
-            self.logger.error("Data couldn't be signed", appointment=extended_appointment.to_dict())
-            signature = None
-
-        self.logger.info("New appointment accepted", locator=extended_appointment.locator)
-
-        return {
-            "locator": extended_appointment.locator,
-            "start_block": extended_appointment.start_block,
-            "signature": signature,
-            "available_slots": available_slots,
-            "subscription_expiry": self.gatekeeper.registered_users[user_id].subscription_expiry,
-        }
+            return {
+                "locator": extended_appointment.locator,
+                "start_block": extended_appointment.start_block,
+                "signature": signature,
+                "available_slots": available_slots,
+                "subscription_expiry": self.gatekeeper.registered_users[user_id].subscription_expiry,
+            }
 
     def do_watch(self):
         """
@@ -481,64 +488,62 @@ class Watcher:
             locator_txid_map = {compute_locator(txid): txid for txid in txids}
             self.locator_cache.update(block_hash, locator_txid_map)
 
-            if len(self.appointments) > 0 and locator_txid_map:
-                outdated_appointments = self.gatekeeper.get_outdated_appointments(block["height"])
-                # Make sure we only try to delete what is on the Watcher (some appointments may have been triggered)
-                outdated_appointments = list(set(outdated_appointments).intersection(self.appointments.keys()))
+            with self.rw_lock.gen_wlock():
+                if len(self.appointments) > 0 and locator_txid_map:
+                    outdated_appointments = self.gatekeeper.get_outdated_appointments(block["height"])
+                    # Make sure we only try to delete what is on the Watcher (some appointments may have been triggered)
+                    outdated_appointments = list(set(outdated_appointments).intersection(self.appointments.keys()))
 
-                Cleaner.delete_outdated_appointments(
-                    outdated_appointments, self.appointments, self.locator_uuid_map, self.db_manager
-                )
-
-                valid_breaches, invalid_breaches = self.filter_breaches(self.get_breaches(locator_txid_map))
-
-                triggered_flags = []
-                appointments_to_delete = []
-
-                for uuid, breach in valid_breaches.items():
-                    self.logger.info(
-                        "Notifying responder and deleting appointment",
-                        penalty_txid=breach["penalty_txid"],
-                        locator=breach["locator"],
-                        uuid=uuid,
+                    Cleaner.delete_outdated_appointments(
+                        outdated_appointments, self.appointments, self.locator_uuid_map, self.db_manager
                     )
 
-                    receipt = self.responder.handle_breach(
-                        uuid,
-                        breach["locator"],
-                        breach["dispute_txid"],
-                        breach["penalty_txid"],
-                        breach["penalty_rawtx"],
-                        self.appointments[uuid].get("user_id"),
-                        block_hash,
+                    valid_breaches, invalid_breaches = self.filter_breaches(self.get_breaches(locator_txid_map))
+
+                    triggered_flags = []
+                    appointments_to_delete = []
+
+                    for uuid, breach in valid_breaches.items():
+                        self.logger.info(
+                            "Notifying responder and deleting appointment",
+                            penalty_txid=breach["penalty_txid"],
+                            locator=breach["locator"],
+                            uuid=uuid,
+                        )
+
+                        receipt = self.responder.handle_breach(
+                            uuid,
+                            breach["locator"],
+                            breach["dispute_txid"],
+                            breach["penalty_txid"],
+                            breach["penalty_rawtx"],
+                            self.appointments[uuid].get("user_id"),
+                            block_hash,
+                        )
+
+                        # FIXME: Only necessary because of the triggered appointment approach. Fix if it changes.
+
+                        if receipt.delivered:
+                            Cleaner.delete_appointment_from_memory(uuid, self.appointments, self.locator_uuid_map)
+                            triggered_flags.append(uuid)
+                        else:
+                            appointments_to_delete.append(uuid)
+
+                    # Appointments are only flagged as triggered if they are delivered, otherwise they are just deleted.
+                    appointments_to_delete.extend(invalid_breaches)
+                    appointments_to_delete_gatekeeper = {
+                        uuid: self.appointments[uuid].get("user_id") for uuid in appointments_to_delete
+                    }
+                    self.db_manager.batch_create_triggered_appointment_flag(triggered_flags)
+
+                    Cleaner.delete_completed_appointments(
+                        appointments_to_delete, self.appointments, self.locator_uuid_map, self.db_manager
                     )
+                    # Remove invalid appointments from the Gatekeeper
+                    self.gatekeeper.delete_appointments(appointments_to_delete_gatekeeper)
 
-                    # FIXME: Only necessary because of the triggered appointment approach. Fix if it changes.
-
-                    if receipt.delivered:
-                        Cleaner.delete_appointment_from_memory(uuid, self.appointments, self.locator_uuid_map)
-                        triggered_flags.append(uuid)
-                    else:
-                        appointments_to_delete.append(uuid)
-
-                # Appointments are only flagged as triggered if they are delivered, otherwise they are just deleted.
-                appointments_to_delete.extend(invalid_breaches)
-                appointments_to_delete_gatekeeper = {
-                    uuid: self.appointments[uuid].get("user_id") for uuid in appointments_to_delete
-                }
-                self.db_manager.batch_create_triggered_appointment_flag(triggered_flags)
-
-                Cleaner.delete_completed_appointments(
-                    appointments_to_delete, self.appointments, self.locator_uuid_map, self.db_manager
-                )
-                # Remove invalid appointments from the Gatekeeper
-                with self.gatekeeper.lock:
-                    Cleaner.delete_gatekeeper_appointments(
-                        appointments_to_delete_gatekeeper, self.gatekeeper.registered_users, self.gatekeeper.user_db
-                    )
-
-                if not self.appointments:
-                    self.logger.info("No more pending appointments")
+                    if not self.appointments:
+                        self.logger.info("No more pending appointments")
 
             # Register the last processed block for the Watcher
             self.db_manager.store_last_block_hash_watcher(block_hash)
@@ -663,7 +668,8 @@ class Watcher:
 
     def get_registered_user_ids(self):
         """Returns the list of user ids of all the registered users."""
-        return list(self.gatekeeper.registered_users.keys())
+        with self.gatekeeper.rw_lock.gen_rlock():
+            return list(self.gatekeeper.registered_users.keys())
 
     def get_user_info(self, user_id):
         """
@@ -676,7 +682,8 @@ class Watcher:
             :obj:`UserInfo <teos.gatekeeper.UserInfo> or :obj:`None`: The user data if found. :obj:`None` if not found,
             or the ``user_id`` is invalid.
         """
-        return self.gatekeeper.registered_users.get(user_id)
+        with self.gatekeeper.rw_lock.gen_rlock():
+            return self.gatekeeper.registered_users.get(user_id)
 
     def get_subscription_info(self, signature):
         """
@@ -686,8 +693,8 @@ class Watcher:
             signature (:obj:`str`): the signature of the request by the user.
 
         Returns:
-            :obj:`UserInfo <teos.gatekeeper.UserInfo> or :obj:`None`: The user's subscription data if found. :obj:`None`
-            if not found, or the ``user_id`` is invalid.
+            :obj:`tuple`: A 2-item tuple containing the user info (:obj:`UserInfo <teos.gatekeeper.UserInfo>) and the
+            list of locators associated with the appointments that match the subscription.
 
         Raises:
             :obj:`SubscriptionExpired`: If the user subscription has expired.
@@ -695,26 +702,24 @@ class Watcher:
 
         message = "get subscription info".encode("utf-8")
         user_id = self.gatekeeper.authenticate_user(message, signature)
-        if self.gatekeeper.has_subscription_expired(user_id):
-            raise SubscriptionExpired(
-                f"Your subscription expired at block {self.gatekeeper.registered_users[user_id].subscription_expiry}"
-            )
+        has_expired, expiry = self.gatekeeper.has_subscription_expired(user_id)
+        if has_expired:
+            raise SubscriptionExpired(f"Your subscription expired at block {expiry}")
 
-        subscription_info = self.gatekeeper.registered_users.get(user_id)
+        with self.gatekeeper.rw_lock.gen_rlock():
+            subscription_info = self.gatekeeper.registered_users.get(user_id)
 
-        locators = []
+        with self.rw_lock.gen_rlock():
+            locators = []
+            for appt_uuid in subscription_info.appointments:
+                if appt_uuid in self.appointments:
+                    locators.append(self.appointments.get(appt_uuid).get("locator"))
+                elif appt_uuid in self.responder.trackers:
+                    locators.append(self.responder.trackers.get(appt_uuid).get("locator"))
+                else:
+                    self.logger.debug("The appointment uuid was not found in the watcher or the responder.")
 
-        for appt_uuid in subscription_info.appointments:
-            if appt_uuid in self.appointments:
-                locators.append(self.appointments.get(appt_uuid).get("locator"))
-            elif appt_uuid in self.responder.trackers:
-                locators.append(self.responder.trackers.get(appt_uuid).get("locator"))
-            else:
-                self.logger.debug("The appointment uuid was not found in the watcher or the responder.")
-
-        subscription_info.locators = locators
-
-        return subscription_info
+        return subscription_info, locators
 
     def get_all_watcher_appointments(self):
         """Returns a dictionary with all the appointment stored in the db for the watcher."""

--- a/test/teos/unit/test_gatekeeper.py
+++ b/test/teos/unit/test_gatekeeper.py
@@ -46,12 +46,14 @@ def test_manage_subscription_expiry(gatekeeper):
 
     # Users expire after this block. Check that they are currently not expired
     for user_id in expiring_users.keys():
-        assert not gatekeeper.has_subscription_expired(user_id)
+        has_subscription_expired, _ = gatekeeper.has_subscription_expired(user_id)
+        assert not has_subscription_expired
 
     # Generate a block and users must have expired
     generate_blocks_with_delay(1)
     for user_id in expiring_users.keys():
-        assert gatekeeper.has_subscription_expired(user_id)
+        has_subscription_expired, _ = gatekeeper.has_subscription_expired(user_id)
+        assert has_subscription_expired
 
     # Users will remain in the registered_users dictionary until expiry_delta blocks later.
     generate_blocks_with_delay(gatekeeper.expiry_delta - 1)
@@ -249,15 +251,18 @@ def test_has_subscription_expired(gatekeeper):
     gatekeeper.registered_users[user_id] = user_info
 
     # Check that the subscription is still live
-    assert not gatekeeper.has_subscription_expired(user_id)
+    has_subscription_expired, expiry = gatekeeper.has_subscription_expired(user_id)
+    assert not has_subscription_expired
 
     # Generating 1 additional block will expire the subscription
     generate_blocks(1)
-    assert gatekeeper.has_subscription_expired(user_id)
+    has_subscription_expired, expiry = gatekeeper.has_subscription_expired(user_id)
+    assert has_subscription_expired
 
     # Check it remains expired afterwards
     generate_blocks(1)
-    assert gatekeeper.has_subscription_expired(user_id)
+    has_subscription_expired, expiry = gatekeeper.has_subscription_expired(user_id)
+    assert has_subscription_expired
 
 
 def test_has_subscription_expired_not_registered(gatekeeper):

--- a/test/teos/unit/test_responder.py
+++ b/test/teos/unit/test_responder.py
@@ -326,7 +326,8 @@ def test_do_watch(temp_db_manager, gatekeeper, carrier, block_processor, generat
         responder.db_manager.store_responder_tracker(uuid, tracker.to_dict())
 
     # Let's start to watch
-    Thread(target=responder.do_watch, daemon=True).start()
+    do_watch_thread = Thread(target=responder.do_watch, daemon=True)
+    do_watch_thread.start()
 
     # And broadcast some of the penalties
     broadcast_txs = []
@@ -360,6 +361,9 @@ def test_do_watch(temp_db_manager, gatekeeper, carrier, block_processor, generat
     # Check they are not in the Gatekeeper either
     for tracker in trackers[5:]:
         assert len(responder.gatekeeper.registered_users[tracker.user_id].appointments) == 0
+
+    chain_monitor.terminate()
+    do_watch_thread.join()
 
 
 def test_check_confirmations(db_manager, gatekeeper, carrier, responder, block_processor):


### PR DESCRIPTION
This basically add RWLocks to:

- `Gatekeeper`
- `Responder`
- `Watcher`

Before this PR, the `InternalAPI` has a RWLock to guard the access to the backend. However, two threads are running for each of the main backend components (`Watcher` and `Responder`), meaning that, theoretically, their `do_watch` method could crash with the user data feeding (`add_appointment` and `handle_breach`). This tries to fix that.

For the `Gatekeeper`:

The writer lock is acquired for the data addition/update (`add_update_*` and `update_outdated_users_cache`) and deletion (`delete_appointments`). The reader lock is acquired for data querying (`authenticate_user`, `has_subscription_expired` and  `get_outdated_users`).

For the `Responder`:

The writer lock is acquired for `add_tracker` (called by `handle_breach`) and for a part of `do_watch` and `handle_reorgs`. Notice that the whole `do_watch` cannot be covered in a single piece since `handle_reorgs` may call `handle_breach` and lead to a deadlock.

For the `Watcher`:

The writer lock is acquired for the most part of `add_appointment` and `do_watch`, whereas the reader lock is acquired for get requests.

The `Watcher`'s block cache is maintaining its own RWLock, even though it could arguably be removed. 

