### PR TITLE
Integrate wsgi logs

### DIFF
--- a/teos/api.py
+++ b/teos/api.py
@@ -85,7 +85,9 @@ def serve(internal_api_endpoint, endpoint, logging_port, min_to_self_delay, auto
     api.logger.info(f"Initialized. Serving at {endpoint}")
 
     if auto_run:
-        wsgi_serve(api.app, listen=endpoint)
+        # Waitress will serve both on IPV4 and IPV6 if localhost is passed as endpoint. Defaulting to IPV4 only in that
+        # case.
+        wsgi_serve(api.app, listen=endpoint.replace("localhost", "127.0.0.1"))
     else:
         return api.app
 

--- a/teos/gunicorn_config.py
+++ b/teos/gunicorn_config.py
@@ -1,0 +1,84 @@
+import os
+import structlog
+from logging.handlers import SocketHandler
+
+
+logging_port = os.environ.get("LOG_SERVER_PORT")
+timestamper = structlog.processors.TimeStamper(fmt="%d/%m/%Y %H:%M:%S")
+
+
+class FormattedSocketHandler(SocketHandler):
+    """ Works in the same way as SocketHandler, but it uses formatters. """
+
+    def emit(self, record):
+        """
+        Works exactly like SocketHandler.emit but formats the record before sending it.
+        record.args is set to none since they are already used by self.format, otherwise makePickle would try to
+        use them again and fail.
+
+        Args:
+            record (:obj:LogRecord <logging.LogRecord>): the record to be emitted.
+        """
+        try:
+            record.msg = self.format(record)
+            record.args = None
+
+            s = self.makePickle(record)
+            self.send(s)
+
+        except Exception:
+            self.handleError(record)
+
+
+def add_component(logger, name, event_dict):
+    """ Adds the component name to the structlog."""
+    event_dict["component"] = "API"
+    return event_dict
+
+
+# Add the timestamp and component to the entry if the entry is not from structlog.
+pre_chain = [timestamper, add_component]
+
+
+# Config dict that will be used by gunicorn
+logconfig_dict = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "loggers": {
+        "gunicorn.error": {
+            "level": "INFO",
+            "handlers": ["error_console"],
+            "propagate": False,
+            "qualname": "gunicorn.error",
+        },
+        "gunicorn.access": {
+            "level": "INFO",
+            "handlers": ["console"],
+            "propagate": False,
+            "qualname": "gunicorn.access",
+        },
+    },
+    "formatters": {
+        "json_formatter": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.processors.JSONRenderer(),
+            "foreign_pre_chain": pre_chain,
+        }
+    },
+    "handlers": {
+        "error_console": {
+            "level": "DEBUG",
+            "class": "teos.gunicorn_config.FormattedSocketHandler",
+            "host": "localhost",
+            "port": logging_port,
+            "formatter": "json_formatter",
+        },
+        "console": {
+            "level": "DEBUG",
+            "class": "teos.gunicorn_config.FormattedSocketHandler",
+            "host": "localhost",
+            "port": logging_port,
+            "formatter": "json_formatter",
+        },
+    },
+}

--- a/teos/gunicorn_config.py
+++ b/teos/gunicorn_config.py
@@ -1,43 +1,9 @@
 import os
 import structlog
-from logging.handlers import SocketHandler
+from teos.logger import add_api_component, timestamper
 
 
 logging_port = os.environ.get("LOG_SERVER_PORT")
-timestamper = structlog.processors.TimeStamper(fmt="%d/%m/%Y %H:%M:%S")
-
-
-class FormattedSocketHandler(SocketHandler):
-    """ Works in the same way as SocketHandler, but it uses formatters. """
-
-    def emit(self, record):
-        """
-        Works exactly like SocketHandler.emit but formats the record before sending it.
-        record.args is set to none since they are already used by self.format, otherwise makePickle would try to
-        use them again and fail.
-
-        Args:
-            record (:obj:LogRecord <logging.LogRecord>): the record to be emitted.
-        """
-        try:
-            record.msg = self.format(record)
-            record.args = None
-
-            s = self.makePickle(record)
-            self.send(s)
-
-        except Exception:
-            self.handleError(record)
-
-
-def add_component(logger, name, event_dict):
-    """ Adds the component name to the structlog."""
-    event_dict["component"] = "API"
-    return event_dict
-
-
-# Add the timestamp and component to the entry if the entry is not from structlog.
-pre_chain = [timestamper, add_component]
 
 
 # Config dict that will be used by gunicorn
@@ -62,20 +28,20 @@ logconfig_dict = {
         "json_formatter": {
             "()": structlog.stdlib.ProcessorFormatter,
             "processor": structlog.processors.JSONRenderer(),
-            "foreign_pre_chain": pre_chain,
+            "foreign_pre_chain": [timestamper, add_api_component],
         }
     },
     "handlers": {
         "error_console": {
             "level": "DEBUG",
-            "class": "teos.gunicorn_config.FormattedSocketHandler",
+            "class": "teos.logger.FormattedSocketHandler",
             "host": "localhost",
             "port": logging_port,
             "formatter": "json_formatter",
         },
         "console": {
             "level": "DEBUG",
-            "class": "teos.gunicorn_config.FormattedSocketHandler",
+            "class": "teos.logger.FormattedSocketHandler",
             "host": "localhost",
             "port": logging_port,
             "formatter": "json_formatter",

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -266,14 +266,17 @@ class TeosDaemon:
         api_endpoint = f"{self.config.get('API_BIND')}:{self.config.get('API_PORT')}"
         if self.config.get("WSGI") == "gunicorn":
             # FIXME: We may like to add workers depending on a config value
+            teos_folder = os.path.dirname(os.path.realpath(__file__))
             self.api_proc = subprocess.Popen(
                 [
                     "gunicorn",
+                    f"--config={os.path.join(teos_folder, 'gunicorn_config.py')}",
                     f"--bind={api_endpoint}",
                     f"teos.api:serve(internal_api_endpoint='{self.internal_api_endpoint}', "
                     f"endpoint='{api_endpoint}', logging_port='{logging_port}', "
                     f"min_to_self_delay='{self.config.get('MIN_TO_SELF_DELAY')}')",
-                ]
+                ],
+                env={**os.environ, **{"LOG_SERVER_PORT": str(logging_port)}},
             )
         else:
             self.api_proc = multiprocessing.Process(


### PR DESCRIPTION
Integrates the gunicorn and waitress logs with the logging server.

The approach is pretty straightforward, but a bit tricky. gunicorn allows a python config file to rewrite how it handles logs. The provided config file `gunicorn_conf.py` adds the timestamp and component to the message in a similar way used by `teos.logger`. The tricky parts comes with `SockerHandler`, since it does not use formatters. 

In order to work around it, `FormattedSocketHandler` is created inheriting from `SockerHandler` and applying the desired formatting before emitting the message. 

For waitress it is a bit easier, since `setup_logging` can be called. However, since it does not use `structlog` some additional config is needed to add the missing parts, in a similar fashion to `gunicorn` (`FormattedSocketHandler` + Timestamper + `add_component`).