### PR TITLE
Fixes circle ci latest tag on releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,12 +79,8 @@ jobs:
           name: docker linux amd64
           command: |
             LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
-            if [ -z "$LATEST_TAG" ]
-            then
-                  LATEST_TAG="latest"
-            fi
-            #
-            sudo docker build --pull -t $DOCKERHUB_REPO:$LATEST_TAG-amd64 -f docker/Dockerfile .
+
+            sudo docker build --pull -t $DOCKERHUB_REPO:$LATEST_TAG-amd64 -t $DOCKERHUB_REPO:latest-amd64 -f docker/Dockerfile .
             sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
             sudo docker push $DOCKERHUB_REPO:$LATEST_TAG-amd64
   publish_docker_linuxarm32:
@@ -99,12 +95,8 @@ jobs:
           command: |
             sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
             LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
-            if [ -z "$LATEST_TAG" ]
-            then
-                  LATEST_TAG="latest"
-            fi
-            #
-            sudo docker build --pull -t $DOCKERHUB_REPO:$LATEST_TAG-arm32v7 -f docker/arm32v7.Dockerfile .
+
+            sudo docker build --pull -t $DOCKERHUB_REPO:$LATEST_TAG-arm32v7 -t $DOCKERHUB_REPO:latest-arm32v7 -f docker/arm32v7.Dockerfile .
             sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
             sudo docker push $DOCKERHUB_REPO:$LATEST_TAG-arm32v7
   publish_docker_linuxarm64:
@@ -119,12 +111,8 @@ jobs:
           command: |
             sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
             LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
-            if [ -z "$LATEST_TAG" ]
-            then
-                  LATEST_TAG="latest"
-            fi
-            #
-            sudo docker build --pull -t $DOCKERHUB_REPO:$LATEST_TAG-arm64v8 -f docker/arm64v8.Dockerfile .
+
+            sudo docker build --pull -t $DOCKERHUB_REPO:$LATEST_TAG-arm64v8 -t $DOCKERHUB_REPO:latest-arm64v8 -f docker/arm64v8.Dockerfile .
             sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
             sudo docker push $DOCKERHUB_REPO:$LATEST_TAG-arm64v8
   publish_docker_multiarch:
@@ -142,17 +130,17 @@ jobs:
             sudo sh -c 'echo "{ \"experimental\": \"enabled\" }" >> $HOME/.docker/config.json'
             #
             sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
-            #
             LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
-            if [ -z "$LATEST_TAG" ]
-            then
-                  LATEST_TAG="latest"
-            fi
-            sudo docker manifest create --amend $DOCKERHUB_REPO:$LATEST_TAG $DOCKERHUB_REPO:$LATEST_TAG-amd64 $DOCKERHUB_REPO:$LATEST_TAG-arm32v7 $DOCKERHUB_REPO:$LATEST_TAG-arm64v8
-            sudo docker manifest annotate $DOCKERHUB_REPO:$LATEST_TAG $DOCKERHUB_REPO:$LATEST_TAG-amd64 --os linux --arch amd64
-            sudo docker manifest annotate $DOCKERHUB_REPO:$LATEST_TAG $DOCKERHUB_REPO:$LATEST_TAG-arm32v7 --os linux --arch arm --variant v7
-            sudo docker manifest annotate $DOCKERHUB_REPO:$LATEST_TAG $DOCKERHUB_REPO:$LATEST_TAG-arm64v8 --os linux --arch arm64 --variant v8
-            sudo docker manifest push $DOCKERHUB_REPO:$LATEST_TAG -p
+
+            # Add the tag for the new version and update latest
+            for TAG in $LATEST_TAG latest
+            do
+              sudo docker manifest create --amend $DOCKERHUB_REPO:$TAG $DOCKERHUB_REPO:$TAG-amd64 $DOCKERHUB_REPO:$TAG-arm32v7 $DOCKERHUB_REPO:$TAG-arm64v8
+              sudo docker manifest annotate $DOCKERHUB_REPO:$TAG $DOCKERHUB_REPO:$TAG-amd64 --os linux --arch amd64
+              sudo docker manifest annotate $DOCKERHUB_REPO:$TAG $DOCKERHUB_REPO:$TAG-arm32v7 --os linux --arch arm --variant v7
+              sudo docker manifest annotate $DOCKERHUB_REPO:$TAG $DOCKERHUB_REPO:$TAG-arm64v8 --os linux --arch arm64 --variant v8
+              sudo docker manifest push $DOCKERHUB_REPO:$TAG -p
+            done
 
 workflows:
   version: 2


### PR DESCRIPTION
Circle-ci was initially configured to build docker images tagged as `latest` every merge into master that was not tagged as a release, and tag with the release number for the ones that had one.

Later on it was modified to only build images for releases, given how long it takes to build the arm images. However, the latest tag part was not updated. Therefore, the `latest` tag was not being updated and builds that relayed on that were building with older versions, like `btcpay-server` docker builds.

This PR updates the circle-ci config to tag every release with the release number and tag it as latest.

Kudos to @whiteyhat for reporting the issue.