### PR TITLE
Fix e2e tests so they work with bitcoind 0.21.0

### DIFF
--- a/test/teos/conftest.py
+++ b/test/teos/conftest.py
@@ -70,6 +70,11 @@ def setup_node():
             )
         )
         try:
+            info = bitcoin_cli.getnetworkinfo()
+
+            if info.get("version") >= 210000:
+                bitcoin_cli.createwallet("test_wallet")
+
             btc_addr = bitcoin_cli.getnewaddress()
             break
 


### PR DESCRIPTION
When I tried running the e2e tests, they would hang indefinitely. While debugging I found that bitcoind would get caught at bitcoin_cli.getnewaddress() in /test/teos/conftest.py, getting the error: `A default wallet is no longer automatically created`

I'm running version 0.21.0 of bitcoin, and it looks like in version 0.21.0 of bitcoind "Bitcoin Core will no longer automatically create new wallets on startup": https://lists.linuxfoundation.org/pipermail/bitcoin-core-dev/2021-January/000097.html

Proposing the following change, which allows tests to run smoothly while running the latest version of bitcoind