### PR TITLE
teos - Adds bitcoind polling to ensure it is alive

### DIFF
--- a/teos/block_processor.py
+++ b/teos/block_processor.py
@@ -17,27 +17,67 @@ class BlockProcessor:
     Args:
         btc_connect_params (:obj:`dict`): a dictionary with the parameters to connect to bitcoind
             (``rpc user, rpc password, host and port``).
+        bitcoind_reachable (:obj:`threading.Event`): signals whether bitcoind is reachable or not.
 
     Attributes:
         logger (:obj:`Logger <teos.logger.Logger>`): the logger for this component.
     """
 
-    def __init__(self, btc_connect_params):
+    def __init__(self, btc_connect_params, bitcoind_reachable):
         self.logger = get_logger(component=BlockProcessor.__name__)
         self.btc_connect_params = btc_connect_params
+        self.bitcoind_reachable = bitcoind_reachable
 
-    def get_block(self, block_hash):
+    def _blocking_query(self, method):
+        """
+        Performs a query to bitcoind checking the ``bitcoin_reachable`` event. If the event is cleared, the query will
+        block until it is set back. If bitcoind is unreachable but the event has still not been cleared, it will be
+        cleared and the query will be performed again.
+
+        This method is required since some methods of the ``BlockProcessor`` need to be called without a lock, while others
+        do need it. For instance, request from the user (register, add_appointment, ...) need to be non-blocking, so the request
+        fails if bitcoind is unreachable intead of being processed once it comes back online potentially once the request has timmed-out.
+        On the other hand, request in the ``do_watch`` thread of the :obj:`teos.watcher.Watcher` and the :obj:`teos.responder.Responder`
+        must have a response to proceed.
+
+        Args:
+            method (:obj:`function`): the BlockProcessor method to be called in a blocking way (usually a lambda).
+
+        Returns:
+            :obj:`Object`: The return of the called method.
+        """
+
+        self.bitcoind_reachable.wait()
+
+        try:
+            result = method()
+
+        except ConnectionRefusedError:
+            self.logger.error(f"Cannot connect to bitcoind. Waiting for it to come back online")
+            self.bitcoind_reachable.clear()
+            result = self._blocking_query(method)
+
+        return result
+
+    def get_block(self, block_hash, blocking=False):
         """
         Gets a block given a block hash by querying ``bitcoind``.
 
         Args:
             block_hash (:obj:`str`): the block hash to be queried.
+            blocking (:obj:`bool`): whether the call should be blocking (wait for bitcoind to be available) or not.
 
         Returns:
             :obj:`dict` or :obj:`None`: A dictionary containing the requested block data if the block is found.
 
             Returns :obj:`None` otherwise.
+
+        Raises:
+            :obj:`ConnectionRefusedError`: if bitcoind cannot be reached.
         """
+
+        if blocking:
+            return self._blocking_query(lambda: self.get_block(block_hash))
 
         try:
             block = bitcoin_cli(self.btc_connect_params).getblock(block_hash)
@@ -48,15 +88,24 @@ class BlockProcessor:
 
         return block
 
-    def get_best_block_hash(self):
+    def get_best_block_hash(self, blocking=False):
         """
         Gets the hash of the current best chain tip.
+
+        Args:
+            blocking (:obj:`bool`): whether the call should be blocking (wait for bitcoind to be available) or not.
 
         Returns:
             :obj:`str` or :obj:`None`: The hash of the block if it can be found.
 
             Returns :obj:`None` otherwise (not even sure this can actually happen).
+
+        Raises:
+            :obj:`ConnectionRefusedError`: if bitcoind cannot be reached.
         """
+
+        if blocking:
+            return self._blocking_query(lambda: self.get_best_block_hash())
 
         try:
             block_hash = bitcoin_cli(self.btc_connect_params).getbestblockhash()
@@ -67,15 +116,24 @@ class BlockProcessor:
 
         return block_hash
 
-    def get_block_count(self):
+    def get_block_count(self, blocking=False):
         """
         Gets the block count of the best chain.
+
+        Args:
+            blocking (:obj:`bool`): whether the call should be blocking (wait for bitcoind to be available) or not.
 
         Returns:
             :obj:`int` or :obj:`None`: The count of the best chain if it can be computed.
 
             Returns :obj:`None` otherwise (not even sure this can actually happen).
+
+        Raises:
+            :obj:`ConnectionRefusedError`: if bitcoind cannot be reached.
         """
+
+        if blocking:
+            return self._blocking_query(lambda: self.get_block_count())
 
         try:
             block_count = bitcoin_cli(self.btc_connect_params).getblockcount()
@@ -86,20 +144,25 @@ class BlockProcessor:
 
         return block_count
 
-    def decode_raw_transaction(self, raw_tx):
+    def decode_raw_transaction(self, raw_tx, blocking=False):
         """
         Deserializes a given raw transaction (hex encoded) and builds a dictionary representing it with all the
         associated metadata given by ``bitcoind`` (e.g. confirmation count).
 
         Args:
             raw_tx (:obj:`str`): the hex representation of the transaction.
+            blocking (:obj:`bool`): whether the call should be blocking (wait for bitcoind to be available) or not.
 
         Returns:
             :obj:`dict`: The decoding of the given ``raw_tx`` if the transaction is well formatted.
 
         Raises:
             :obj:`InvalidTransactionFormat`: If the `provided ``raw_tx`` has invalid format.
+            :obj:`ConnectionRefusedError`: if bitcoind cannot be reached.
         """
+
+        if blocking:
+            return self._blocking_query(lambda: self.decode_raw_transaction(raw_tx))
 
         try:
             tx = bitcoin_cli(self.btc_connect_params).decoderawtransaction(raw_tx)
@@ -111,26 +174,30 @@ class BlockProcessor:
 
         return tx
 
-    def get_distance_to_tip(self, target_block_hash):
+    def get_distance_to_tip(self, target_block_hash, blocking=False):
         """
         Compute the distance between a given block hash and the best chain tip.
 
         Args:
             target_block_hash (:obj:`str`): the hash of the target block (the one to compute the distance form the tip).
+            blocking (:obj:`bool`): whether the call should be blocking (wait for bitcoind to be available) or not.
 
         Returns:
             :obj:`int` or :obj:`None`: The distance between the target and the best chain tip is the target block can be
             found on the blockchain.
 
             Returns :obj:`None` otherwise.
+
+        Raises:
+            :obj:`ConnectionRefusedError`: if bitcoind cannot be reached.
         """
 
         distance = None
 
-        chain_tip = self.get_best_block_hash()
-        chain_tip_height = self.get_block(chain_tip).get("height")
+        chain_tip = self.get_best_block_hash(blocking)
+        chain_tip_height = self.get_block(chain_tip, blocking).get("height")
 
-        target_block = self.get_block(target_block_hash)
+        target_block = self.get_block(target_block_hash, blocking)
 
         if target_block is not None:
             target_block_height = target_block.get("height")
@@ -139,7 +206,7 @@ class BlockProcessor:
 
         return distance
 
-    def get_missed_blocks(self, last_know_block_hash):
+    def get_missed_blocks(self, last_know_block_hash, blocking=False):
         """
         Gets the blocks between the current best chain tip and a given block hash (``last_know_block_hash``).
 
@@ -147,24 +214,28 @@ class BlockProcessor:
 
         Args:
             last_know_block_hash (:obj:`str`): the hash of the last known block.
+            blocking (:obj:`bool`): whether the call should be blocking (wait for bitcoind to be available) or not.
 
         Returns:
             :obj:`list`: A list of blocks between the last given block and the current best chain tip, starting from the
             child of ``last_know_block_hash``.
+
+        Raises:
+            :obj:`ConnectionRefusedError`: if bitcoind cannot be reached.
         """
 
-        current_block_hash = self.get_best_block_hash()
+        current_block_hash = self.get_best_block_hash(blocking)
         missed_blocks = []
 
         while current_block_hash != last_know_block_hash and current_block_hash is not None:
             missed_blocks.append(current_block_hash)
 
-            current_block = self.get_block(current_block_hash)
+            current_block = self.get_block(current_block_hash, blocking)
             current_block_hash = current_block.get("previousblockhash")
 
         return missed_blocks[::-1]
 
-    def is_block_in_best_chain(self, block_hash):
+    def is_block_in_best_chain(self, block_hash, blocking=False):
         """
         Checks whether a given block is on the best chain or not. Blocks are identified by block_hash.
 
@@ -173,15 +244,17 @@ class BlockProcessor:
 
         Args:
             block_hash(:obj:`str`): the hash of the block to be checked.
+            blocking (:obj:`bool`): whether the call should be blocking (wait for bitcoind to be available) or not.
 
         Returns:
             :obj:`bool`: True if the block is on the best chain, False otherwise.
 
         Raises:
-            KeyError: If the block cannot be found in the blockchain.
+            :obj:`KeyError`: if the block cannot be found in the blockchain.
+            :obj:`ConnectionRefusedError`: if bitcoind cannot be reached.
         """
 
-        block = self.get_block(block_hash)
+        block = self.get_block(block_hash, blocking)
 
         if block is None:
             # This should never happen as long as we are using the same node, since bitcoind never drops orphan blocks
@@ -193,7 +266,7 @@ class BlockProcessor:
         else:
             return False
 
-    def find_last_common_ancestor(self, last_known_block_hash):
+    def find_last_common_ancestor(self, last_known_block_hash, blocking=False):
         """
         Finds the last common ancestor between the current best chain tip and the last block known by us (older block).
 
@@ -201,18 +274,22 @@ class BlockProcessor:
 
         Args:
             last_known_block_hash(:obj:`str`): the hash of the last know block.
+            blocking (:obj:`bool`): whether the call should be blocking (wait for bitcoind to be available) or not.
 
         Returns:
             :obj:`tuple`: A tuple (:obj:`str`, :obj:`list`) where the first item contains the hash of the last common
             ancestor and the second item contains the list of transactions from ``last_known_block_hash`` to
             ``last_common_ancestor``.
+
+        Raises:
+            :obj:`ConnectionRefusedError`: if bitcoind cannot be reached.
         """
 
         target_block_hash = last_known_block_hash
         dropped_txs = []
 
-        while not self.is_block_in_best_chain(target_block_hash):
-            block = self.get_block(target_block_hash)
+        while not self.is_block_in_best_chain(target_block_hash, blocking):
+            block = self.get_block(target_block_hash, blocking)
             dropped_txs.extend(block.get("tx"))
             target_block_hash = block.get("previousblockhash")
 

--- a/teos/internal_api.py
+++ b/teos/internal_api.py
@@ -80,9 +80,17 @@ class _InternalAPI(TowerServicesServicer):
             )
 
         except InvalidParameter as e:
-            context.set_details(e.msg)
-            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
-            return RegisterResponse()
+            msg = e.msg
+            status_code = grpc.StatusCode.INVALID_ARGUMENT
+
+        except ConnectionRefusedError:
+            msg = "Service unavailable"
+            status_code = grpc.StatusCode.UNAVAILABLE
+
+        context.set_details(msg)
+        context.set_code(status_code)
+
+        return RegisterResponse()
 
     def add_appointment(self, request, context):
         """Processes the request to add an appointment from a user."""
@@ -107,6 +115,10 @@ class _InternalAPI(TowerServicesServicer):
         except AppointmentAlreadyTriggered:
             msg = "The provided appointment has already been triggered"
             status_code = grpc.StatusCode.ALREADY_EXISTS
+
+        except ConnectionRefusedError:
+            msg = "Service unavailable"
+            status_code = grpc.StatusCode.UNAVAILABLE
 
         context.set_details(msg)
         context.set_code(status_code)
@@ -144,6 +156,10 @@ class _InternalAPI(TowerServicesServicer):
             msg = str(e)
             status_code = grpc.StatusCode.UNAUTHENTICATED
 
+        except ConnectionRefusedError:
+            msg = "Service unavailable"
+            status_code = grpc.StatusCode.UNAVAILABLE
+
         context.set_details(msg)
         context.set_code(status_code)
 
@@ -166,12 +182,18 @@ class _InternalAPI(TowerServicesServicer):
 
         except AuthenticationFailure:
             msg = "User not found. Have you registered?"
+            status_code = grpc.StatusCode.UNAUTHENTICATED
 
         except SubscriptionExpired as e:
             msg = str(e)
+            status_code = grpc.StatusCode.UNAUTHENTICATED
+
+        except ConnectionRefusedError:
+            msg = "Service unavailable"
+            status_code = grpc.StatusCode.UNAVAILABLE
 
         context.set_details(msg)
-        context.set_code(grpc.StatusCode.UNAUTHENTICATED)
+        context.set_code(status_code)
 
         return GetUserResponse()
 

--- a/teos/responder.py
+++ b/teos/responder.py
@@ -197,7 +197,7 @@ class Responder:
             :obj:`bool`: Whether or not the :obj:`Responder` and ``bitcoind`` are on sync.
         """
 
-        distance_from_tip = self.block_processor.get_distance_to_tip(block_hash)
+        distance_from_tip = self.block_processor.get_distance_to_tip(block_hash, blocking=True)
 
         if distance_from_tip is not None and distance_from_tip > 1:
             synchronized = False
@@ -287,7 +287,7 @@ class Responder:
 
         # Distinguish fresh bootstraps from bootstraps from db
         if self.last_known_block is None:
-            self.last_known_block = self.block_processor.get_best_block_hash()
+            self.last_known_block = self.block_processor.get_best_block_hash(blocking=True)
             self.db_manager.store_last_block_hash_responder(self.last_known_block)
 
         while True:
@@ -297,7 +297,7 @@ class Responder:
             if block_hash == ChainMonitor.END_MESSAGE:
                 break
 
-            block = self.block_processor.get_block(block_hash)
+            block = self.block_processor.get_block(block_hash, blocking=True)
             self.logger.info(
                 "New block received", block_hash=block_hash, prev_block_hash=block.get("previousblockhash")
             )

--- a/test/teos/unit/conftest.py
+++ b/test/teos/unit/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from shutil import rmtree
+from threading import Event
 from coincurve import PrivateKey
 
 from teos.carrier import Carrier
@@ -26,6 +27,8 @@ from test.teos.conftest import (
 
 bitcoind_connect_params = {k: v for k, v in config.items() if k.startswith("BTC")}
 bitcoind_feed_params = {k: v for k, v in config.items() if k.startswith("BTC_FEED")}
+bitcoind_reachable = Event()
+bitcoind_reachable.set()
 
 
 @pytest.fixture(scope="module")
@@ -52,12 +55,12 @@ def user_db_manager():
 
 @pytest.fixture(scope="module")
 def carrier(run_bitcoind):
-    return Carrier(bitcoind_connect_params)
+    return Carrier(bitcoind_connect_params, bitcoind_reachable)
 
 
 @pytest.fixture(scope="module")
 def block_processor(run_bitcoind):
-    return BlockProcessor(bitcoind_connect_params)
+    return BlockProcessor(bitcoind_connect_params, bitcoind_reachable)
 
 
 @pytest.fixture(scope="module")

--- a/test/teos/unit/conftest.py
+++ b/test/teos/unit/conftest.py
@@ -1,4 +1,7 @@
+import time
 import pytest
+import threading
+from copy import deepcopy
 from shutil import rmtree
 from threading import Event
 from coincurve import PrivateKey
@@ -26,6 +29,8 @@ from test.teos.conftest import (
 
 
 bitcoind_connect_params = {k: v for k, v in config.items() if k.startswith("BTC")}
+wrong_bitcoind_connect_params = deepcopy(bitcoind_connect_params)
+wrong_bitcoind_connect_params["BTC_RPC_PORT"] = 1234
 bitcoind_feed_params = {k: v for k, v in config.items() if k.startswith("BTC_FEED")}
 bitcoind_reachable = Event()
 bitcoind_reachable.set()
@@ -127,3 +132,32 @@ def generate_dummy_tracker(run_bitcoind):
         return TransactionTracker.from_dict(tracker_data)
 
     return _generate_dummy_tracker
+
+
+# Mocks the return of methods trying to query bitcoind while it cannot be reached
+def mock_connection_refused_return(*args, **kwargs):
+    raise ConnectionRefusedError()
+
+
+def set_bitcoind_reachable(bitcoind_reachable):
+    # Sets the bitcoind_reachable event after a timeout so it can be used to tests the blocking functionality
+    time.sleep(2)
+    bitcoind_reachable.set()
+
+
+def run_test_command_bitcoind_crash(command):
+    # Test without blocking
+    with pytest.raises(ConnectionRefusedError):
+        command()
+
+
+def run_test_blocking_command_bitcoind_crash(event, command):
+    # Clear the lock and try it blocking using the valid BlockProcessor
+    event.clear()
+    t = threading.Thread(target=set_bitcoind_reachable, args=[event])
+    t.start()
+
+    # This should not return an exception
+    command()
+    t.join()
+    event.set()

--- a/test/teos/unit/test_carrier.py
+++ b/test/teos/unit/test_carrier.py
@@ -1,8 +1,11 @@
-from test.teos.conftest import generate_blocks
-from test.teos.unit.conftest import get_random_value_hex
 from teos.utils.rpc_errors import RPC_VERIFY_ALREADY_IN_CHAIN, RPC_DESERIALIZATION_ERROR
 
+from test.teos.conftest import generate_blocks
 from test.teos.conftest import create_commitment_tx, bitcoin_cli
+from test.teos.unit.conftest import (
+    get_random_value_hex,
+    run_test_blocking_command_bitcoind_crash,
+)
 
 
 # FIXME: This test do not fully cover the carrier since the simulator does not support every single error bitcoind may
@@ -64,3 +67,21 @@ def test_get_non_existing_transaction(carrier):
     tx_info = carrier.get_transaction(get_random_value_hex(32))
 
     assert tx_info is None
+
+
+# TESTS WITH BITCOIND UNREACHABLE
+
+
+def test_send_transaction_bitcoind_crash(carrier):
+    tx = create_commitment_tx()
+    txid = bitcoin_cli.decoderawtransaction(tx).get("txid")
+
+    run_test_blocking_command_bitcoind_crash(
+        carrier.bitcoind_reachable, lambda: carrier.send_transaction(tx, txid),
+    )
+
+
+def test_get_transaction_bitcoind_crash(carrier):
+    run_test_blocking_command_bitcoind_crash(
+        carrier.bitcoind_reachable, lambda: carrier.get_transaction(get_random_value_hex(32)),
+    )

--- a/test/teos/unit/test_responder.py
+++ b/test/teos/unit/test_responder.py
@@ -28,7 +28,9 @@ from test.teos.unit.conftest import get_random_value_hex, bitcoind_feed_params
 @pytest.fixture
 def responder(db_manager, gatekeeper, carrier, block_processor):
     responder = Responder(db_manager, gatekeeper, carrier, block_processor)
-    chain_monitor = ChainMonitor([Queue(), responder.block_queue], block_processor, bitcoind_feed_params)
+    chain_monitor = ChainMonitor(
+        [Queue(), responder.block_queue], block_processor, bitcoind_feed_params, block_processor.bitcoind_reachable
+    )
     chain_monitor.monitor_chain()
     responder_thread = responder.awake()
     chain_monitor.activate()

--- a/test/teos/unit/test_watcher.py
+++ b/test/teos/unit/test_watcher.py
@@ -2,7 +2,7 @@ import pytest
 from uuid import uuid4
 from shutil import rmtree
 from copy import deepcopy
-from threading import Thread
+from threading import Thread, Event
 from coincurve import PrivateKey
 
 from teos.carrier import Carrier
@@ -63,8 +63,11 @@ def temp_db_manager():
 
 @pytest.fixture(scope="module")
 def watcher(run_bitcoind, db_manager, gatekeeper):
-    block_processor = BlockProcessor(bitcoind_connect_params)
-    carrier = Carrier(bitcoind_connect_params)
+    bitcoind_reachable = Event()
+    bitcoind_reachable.set()
+
+    block_processor = BlockProcessor(bitcoind_connect_params, bitcoind_reachable)
+    carrier = Carrier(bitcoind_connect_params, bitcoind_reachable)
 
     responder = Responder(db_manager, gatekeeper, carrier, block_processor)
     watcher = Watcher(

--- a/test/teos/unit/test_watcher.py
+++ b/test/teos/unit/test_watcher.py
@@ -1,4 +1,6 @@
+import time
 import pytest
+import threading
 from uuid import uuid4
 from shutil import rmtree
 from copy import deepcopy
@@ -39,6 +41,9 @@ from test.teos.unit.conftest import (
     generate_keypair,
     bitcoind_feed_params,
     bitcoind_connect_params,
+    run_test_command_bitcoind_crash,
+    run_test_blocking_command_bitcoind_crash,
+    mock_connection_refused_return,
 )
 
 APPOINTMENTS = 5
@@ -59,6 +64,32 @@ def temp_db_manager():
 
     db_manager.db.close()
     rmtree(db_name)
+
+
+@pytest.fixture
+def standalone_watcher(run_bitcoind, db_manager, gatekeeper):
+    # This is used when we don't want a Watcher tied to a ChainManager (basically so the latter does not mess with
+    # the bitcoind_reachable event that we are mocking). Therefore we need to create a fresh BlockProcessor.
+    bitcoind_reachable = Event()
+    bitcoind_reachable.set()
+
+    block_processor = BlockProcessor(bitcoind_connect_params, bitcoind_reachable)
+    carrier = Carrier(bitcoind_connect_params, bitcoind_reachable)
+
+    responder = Responder(db_manager, gatekeeper, carrier, block_processor)
+    watcher = Watcher(
+        db_manager,
+        gatekeeper,
+        block_processor,
+        responder,
+        signing_key,
+        MAX_APPOINTMENTS,
+        config.get("LOCATOR_CACHE_SIZE"),
+    )
+
+    watcher.last_known_block = block_processor.get_best_block_hash()
+
+    return watcher
 
 
 @pytest.fixture(scope="module")
@@ -797,3 +828,94 @@ def test_get_subscription_info(block_processor, watcher, generate_dummy_appointm
     assert set(locators) == set([appointment.locator, tracker.locator])
     assert sub_info.available_slots == available_slots
     assert sub_info.subscription_expiry == subscription_expiry
+
+
+# TESTS WITH BITCOIND UNREACHABLE
+# An authenticate_user function that simply does not raise
+def authenticate_user_mock(*args, **kwargs):
+    return get_random_value_hex(32)
+
+
+def test_locator_cache_init_bitcoind_crash(block_processor):
+    locator_cache = LocatorCache(config.get("LOCATOR_CACHE_SIZE"))
+
+    run_test_blocking_command_bitcoind_crash(
+        block_processor.bitcoind_reachable,
+        lambda: locator_cache.init(block_processor.get_best_block_hash(), block_processor),
+    )
+
+
+def test_fix_cache_bitcoind_crash(block_processor):
+    locator_cache = LocatorCache(config.get("LOCATOR_CACHE_SIZE"))
+
+    run_test_blocking_command_bitcoind_crash(
+        block_processor.bitcoind_reachable,
+        lambda: locator_cache.fix(block_processor.get_best_block_hash(), block_processor),
+    )
+
+
+def test_register_bitcoind_crash(watcher, monkeypatch):
+    monkeypatch.setattr(watcher.gatekeeper, "add_update_user", mock_connection_refused_return)
+
+    run_test_command_bitcoind_crash(lambda: watcher.register(get_random_value_hex(32)))
+
+
+def test_get_appointment_bitcoind_crash(watcher, monkeypatch):
+    # We don't need to get the right user, just not to fail, checking if a subscription has expired will return
+    # ConnectionRefusedError, which is what we need to test for.
+    monkeypatch.setattr(watcher.gatekeeper, "authenticate_user", authenticate_user_mock)
+    monkeypatch.setattr(watcher.gatekeeper, "has_subscription_expired", mock_connection_refused_return)
+
+    run_test_command_bitcoind_crash(lambda: watcher.get_appointment(get_random_value_hex(32), get_random_value_hex(32)))
+
+
+def test_add_appointment_bitcoind_crash(watcher, generate_dummy_appointment, monkeypatch):
+    # Same as with the previous test, we just need to check that the ConnectionRefusedError raised by
+    # has_subscription_expired is forwarded.
+    monkeypatch.setattr(watcher.gatekeeper, "authenticate_user", authenticate_user_mock)
+    monkeypatch.setattr(watcher.gatekeeper, "has_subscription_expired", mock_connection_refused_return)
+
+    appointment, _ = generate_dummy_appointment()
+    run_test_command_bitcoind_crash(lambda: watcher.add_appointment(appointment, get_random_value_hex(73)))
+
+
+def test_get_subscription_info_bitcoind_crash(watcher, monkeypatch):
+    # Same approach as the two previous tests
+    monkeypatch.setattr(watcher.gatekeeper, "authenticate_user", authenticate_user_mock)
+    monkeypatch.setattr(watcher.gatekeeper, "has_subscription_expired", mock_connection_refused_return)
+
+    run_test_command_bitcoind_crash(lambda: watcher.get_subscription_info(get_random_value_hex(73)))
+
+
+def test_do_watch_bitcoind_crash(standalone_watcher):
+    # Let's start to watch
+    do_watch_thread = Thread(target=standalone_watcher.do_watch, daemon=True)
+    do_watch_thread.start()
+    time.sleep(2)
+
+    # Block the watcher
+    standalone_watcher.block_processor.bitcoind_reachable.clear()
+    assert standalone_watcher.block_queue.empty()
+
+    # Mine a block and check how the Watcher is blocked processing it
+    best_tip = generate_blocks_with_delay(1, 2)[0]
+    standalone_watcher.block_queue.put(best_tip)
+    time.sleep(2)
+    assert standalone_watcher.last_known_block != best_tip
+    assert standalone_watcher.block_queue.unfinished_tasks == 1
+
+    # Reestablish the connection and check back
+    standalone_watcher.block_processor.bitcoind_reachable.set()
+    time.sleep(2)
+    assert standalone_watcher.last_known_block == best_tip
+    assert standalone_watcher.block_queue.unfinished_tasks == 0
+
+
+def test_check_breach_bitcoind_crash(watcher, generate_dummy_appointment):
+    uuid = uuid4().hex
+    appointment, dispute_tx = generate_dummy_appointment()
+    dispute_txid = watcher.block_processor.decode_raw_transaction(dispute_tx).get("txid")
+
+    run_test_blocking_command_bitcoind_crash(
+        watcher.block_processor.bitcoind_reachable, lambda: watcher.check_breach(uuid, appointment, dispute_txid)
+    )


### PR DESCRIPTION
The ChainMonitor polling thread now is also used to make sure bitcoind has not crashed. Locks have been added so the ChainMonitor thread can lock other background threads if bitcoind is down. This does not apply to user requests, since they need to give a timely response to the user.

In a nutshell, every time a thread makes a (blocking) call to bitcoind, if a `ConnectionRefusedError` is returned, the lock will be cleared and the function will be called recursively (this second time being blocked by the lock).

On the other hand, the `ChainMonitor` polling thread is the one in charge of setting the lock once the connection with bitcoind is reestablished, unblocking all other thread if applicable.

There are calls that should always be blocking, like the ones made by the `Carrier` or the ones makes by the `do_watch` threads of the `Watcher` and the `Responder` (trough the `BlockProcessor`). Therefore, the methods of the latter have a flag to indicate whether the query should be blocking or not. An example of non-blocking queries is a request from the user, that should be hold until the connection is reestablish but fail and notify the user that the service is unavailable, so it can try again later.

It's worth mentioning that bitcoind crashes should be rather uncommon, but this was still a non-handled edge case.