### PR TITLE
Fixes teosd getopt and adds more friendly output to teosd and cli

### DIFF
--- a/contrib/client/teos_client.py
+++ b/contrib/client/teos_client.py
@@ -565,12 +565,12 @@ def run():
         if command in commands:
             main(command, args, command_line_conf)
         elif not command:
-            sys.exit("No command provided. Use help to check the list of available commands")
+            sys.exit(f"No command provided.\n\n{show_usage()}")
         else:
-            sys.exit("Unknown command. Use help to check the list of available commands")
+            sys.exit(f"Unknown command.\n\n{show_usage()}")
 
     except GetoptError as e:
-        sys.exit("{}".format(e))
+        sys.exit(f"{e}\n\n{show_usage()}")
 
 
 if __name__ == "__main__":

--- a/teos/cli/teos_cli.py
+++ b/teos/cli/teos_cli.py
@@ -313,7 +313,7 @@ def run():
     try:
         command_index = next(i for i in range(len(argv)) if i > 0 and not argv[i].startswith("-"))
     except StopIteration:
-        sys.exit(show_usage())
+        sys.exit(f"No command found\n\n{show_usage()}")
 
     command = argv[command_index]
     global_options = argv[1:command_index]
@@ -345,7 +345,7 @@ def run():
             if opt in ["-h", "--help"]:
                 sys.exit(show_usage())
     except GetoptError as e:
-        sys.exit("{}".format(e))
+        sys.exit(f"{e}\n\n{show_usage()}")
 
     if command in CLI.COMMANDS:
         cli = CLI(data_dir, command_line_conf)

--- a/teos/teosd.py
+++ b/teos/teosd.py
@@ -416,29 +416,30 @@ def run():
     command_line_conf = {}
     data_dir = DATA_DIR
 
-    opts, _ = getopt(
-        argv[1:],
-        "hd",
-        [
-            "apibind=",
-            "apiport=",
-            "rpcbind=",
-            "rpcport=",
-            "btcnetwork=",
-            "btcrpcuser=",
-            "btcrpcpassword=",
-            "btcrpcconnect=",
-            "btcrpcport=",
-            "btcfeedconnect=",
-            "btcfeedport=",
-            "datadir=",
-            "wsgi=",
-            "daemon",
-            "overwritekey",
-            "help",
-        ],
-    )
     try:
+        opts, _ = getopt(
+            argv[1:],
+            "hd",
+            [
+                "apibind=",
+                "apiport=",
+                "rpcbind=",
+                "rpcport=",
+                "btcnetwork=",
+                "btcrpcuser=",
+                "btcrpcpassword=",
+                "btcrpcconnect=",
+                "btcrpcport=",
+                "btcfeedconnect=",
+                "btcfeedport=",
+                "datadir=",
+                "wsgi=",
+                "daemon",
+                "overwritekey",
+                "help",
+            ],
+        )
+
         for opt, arg in opts:
             if opt in ["--apibind"]:
                 command_line_conf["API_BIND"] = arg
@@ -489,7 +490,7 @@ def run():
                 exit(show_usage())
 
     except GetoptError as e:
-        exit(e)
+        exit(f"{e}\n\n{show_usage()}")
 
     config = get_config(command_line_conf, data_dir)
 


### PR DESCRIPTION
Capturing wrong options was moved out of the try/except in 3ea8806fcfcf2c4979bdd35bc4a6cebef8cb06b for teosd, making it fail if a wrong option was passed.

Partially addresses #283 