### PR TITLE
Refuse to run if unknown config parameters are found

### DIFF
--- a/common/config_loader.py
+++ b/common/config_loader.py
@@ -2,6 +2,12 @@ import os
 import configparser
 
 
+class UnknownConfigParam(ValueError):
+    """An exception for unknown configuration parameters found in config files"""
+
+    pass
+
+
 class ConfigLoader:
     """
      The :class:`ConfigLoader` class is in charge of loading all the configuration parameters to create a config dict
@@ -44,6 +50,9 @@ class ConfigLoader:
 
         Returns:
             :obj:`dict`: A dictionary containing all the configuration parameters.
+
+        Raises:
+            UnknownConfigParam: if an unknown configuration value if found in the configuration file.
         """
 
         if os.path.exists(self.conf_file_path):
@@ -66,6 +75,8 @@ class ConfigLoader:
                                 self.conf_fields[k_upper]["value"] = v
 
                             self.overwritten_fields.add(k_upper)
+                        else:
+                            raise UnknownConfigParam(f"Unknown configuration value {k}")
 
         # Override the command line parameters to the defaults / conf file
         for k, v in self.command_line_conf.items():

--- a/contrib/client/teos_client.py
+++ b/contrib/client/teos_client.py
@@ -16,9 +16,9 @@ from requests.exceptions import MissingSchema, InvalidSchema, InvalidURL
 from common import constants
 import common.receipts as receipts
 from common.appointment import Appointment
-from common.config_loader import ConfigLoader
 from common.cryptographer import Cryptographer
 from common.tools import setup_data_folder
+from common.config_loader import ConfigLoader, UnknownConfigParam
 from common.exceptions import BasicException, InvalidKey, InvalidParameter, TowerResponseError
 from common.tools import is_256b_hex_str, is_locator, compute_locator, is_compressed_pk
 
@@ -436,11 +436,7 @@ def save_appointment_receipt(appointment, start_block, signature, appointments_f
         raise IOError("There was an error while saving the appointment. {}".format(e))
 
 
-def main(command, args, command_line_conf):
-    # Loads config and sets up the data folder and log file
-    config_loader = ConfigLoader(DATA_DIR, CONF_FILE_NAME, DEFAULT_CONF, command_line_conf)
-    config = config_loader.build_config()
-
+def main(command, args, config):
     setup_data_folder(config.get("DATA_DIR"))
 
     # Set the teos url
@@ -563,7 +559,9 @@ def run():
 
         command = args.pop(0) if args else None
         if command in commands:
-            main(command, args, command_line_conf)
+            config_loader = ConfigLoader(DATA_DIR, CONF_FILE_NAME, DEFAULT_CONF, command_line_conf)
+            config = config_loader.build_config()
+            main(command, args, config)
         elif not command:
             sys.exit(f"No command provided.\n\n{show_usage()}")
         else:
@@ -571,6 +569,8 @@ def run():
 
     except GetoptError as e:
         sys.exit(f"{e}\n\n{show_usage()}")
+    except UnknownConfigParam as e:
+        exit(f"{e}. Check your teos_client.conf file")
 
 
 if __name__ == "__main__":

--- a/teos/template.conf
+++ b/teos/template.conf
@@ -18,7 +18,3 @@ subscription_slots = 100
 max_appointments = 1000000
 expiry_delta = 6
 min_to_self_delay = 20
-
-# [chain monitor]
-polling_delta = 60
-block_window_size = 10


### PR DESCRIPTION
Unknown configuration values from the config file were ignored silently. From now on we'll report and refuse to run if any is found.

Partially addresses #283 