### PR TITLE
teos - Unifies delete_completed and delete_outdated appointments in the Cleaner

### DIFF
--- a/teos/watcher.py
+++ b/teos/watcher.py
@@ -499,8 +499,8 @@ class Watcher:
                     # Make sure we only try to delete what is on the Watcher (some appointments may have been triggered)
                     outdated_appointments = list(set(outdated_appointments).intersection(self.appointments.keys()))
 
-                    Cleaner.delete_outdated_appointments(
-                        outdated_appointments, self.appointments, self.locator_uuid_map, self.db_manager
+                    Cleaner.delete_appointments(
+                        outdated_appointments, self.appointments, self.locator_uuid_map, self.db_manager, outdated=True
                     )
 
                     valid_breaches, invalid_breaches = self.filter_breaches(self.get_breaches(locator_txid_map))
@@ -541,7 +541,7 @@ class Watcher:
                     }
                     self.db_manager.batch_create_triggered_appointment_flag(triggered_flags)
 
-                    Cleaner.delete_completed_appointments(
+                    Cleaner.delete_appointments(
                         appointments_to_delete, self.appointments, self.locator_uuid_map, self.db_manager
                     )
                     # Remove invalid appointments from the Gatekeeper

--- a/test/teos/unit/test_cleaner.py
+++ b/test/teos/unit/test_cleaner.py
@@ -177,8 +177,7 @@ def test_update_delete_db_locator_map(db_manager):
             assert uuid in locator_map_before and uuid not in locator_map_after
 
 
-# FIXME: #288
-def test_delete_outdated_appointments(db_manager):
+def test_delete_appointments(db_manager):
     # Tests deleting appointment data both from memory and the database
     for _ in range(ITERATIONS):
         appointments, locator_uuid_map = set_up_appointments(db_manager, MAX_ITEMS)
@@ -193,7 +192,7 @@ def test_delete_outdated_appointments(db_manager):
         assert set(outdated_appointments).issubset(db_appointments.keys())
 
         # Delete
-        Cleaner.delete_outdated_appointments(outdated_appointments, appointments, locator_uuid_map, db_manager)
+        Cleaner.delete_appointments(outdated_appointments, appointments, locator_uuid_map, db_manager)
 
         # Data is not in memory anymore
         all_uuids = list(flatten(locator_uuid_map.values()))
@@ -203,32 +202,6 @@ def test_delete_outdated_appointments(db_manager):
         # And neither is in the database
         db_appointments = db_manager.load_watcher_appointments()
         assert not set(outdated_appointments).issubset(db_appointments.keys())
-
-
-def test_delete_completed_appointments(db_manager):
-    for _ in range(ITERATIONS):
-        appointments, locator_uuid_map = set_up_appointments(db_manager, MAX_ITEMS)
-        completed_appointments = random.sample(list(appointments.keys()), k=ITEMS)
-
-        # Check that the data is there before deletion
-        all_uuids = list(flatten(locator_uuid_map.values()))
-        assert set(completed_appointments).issubset(appointments.keys())
-        assert set(completed_appointments).issubset(all_uuids)
-
-        db_appointments = db_manager.load_watcher_appointments()
-        assert set(completed_appointments).issubset(db_appointments.keys())
-
-        # Delete
-        Cleaner.delete_outdated_appointments(completed_appointments, appointments, locator_uuid_map, db_manager)
-
-        # Data is not in memory anymore
-        all_uuids = list(flatten(locator_uuid_map.values()))
-        assert not set(completed_appointments).issubset(appointments.keys())
-        assert not set(completed_appointments).issubset(all_uuids)
-
-        # And neither is in the database
-        db_appointments = db_manager.load_watcher_appointments()
-        assert not set(completed_appointments).issubset(db_appointments.keys())
 
 
 def test_flag_triggered_appointments(db_manager):


### PR DESCRIPTION
Both methods do the exact same, but the log messages are different.

close #288 