### PR TITLE
Stops backing up the locator_uuid_map

### DIFF
--- a/teos/watcher.py
+++ b/teos/watcher.py
@@ -499,8 +499,8 @@ class Watcher:
                     # Make sure we only try to delete what is on the Watcher (some appointments may have been triggered)
                     outdated_appointments = list(set(outdated_appointments).intersection(self.appointments.keys()))
 
-                    Cleaner.delete_outdated_appointments(
-                        outdated_appointments, self.appointments, self.locator_uuid_map, self.db_manager
+                    Cleaner.delete_appointments(
+                        outdated_appointments, self.appointments, self.locator_uuid_map, self.db_manager, outdated=True
                     )
 
                     valid_breaches, invalid_breaches = self.filter_breaches(self.get_breaches(locator_txid_map))
@@ -541,7 +541,7 @@ class Watcher:
                     }
                     self.db_manager.batch_create_triggered_appointment_flag(triggered_flags)
 
-                    Cleaner.delete_completed_appointments(
+                    Cleaner.delete_appointments(
                         appointments_to_delete, self.appointments, self.locator_uuid_map, self.db_manager
                     )
                     # Remove invalid appointments from the Gatekeeper

--- a/teos/watcher.py
+++ b/teos/watcher.py
@@ -412,7 +412,6 @@ class Watcher:
                     # Otherwise it is dropped.
                     if receipt.delivered:
                         self.db_manager.store_watcher_appointment(uuid, extended_appointment.to_dict())
-                        self.db_manager.create_append_locator_map(extended_appointment.locator, uuid)
                         self.db_manager.create_triggered_appointment_flag(uuid)
 
                 except (EncryptionError, InvalidTransactionFormat):
@@ -434,7 +433,6 @@ class Watcher:
                     self.locator_uuid_map[extended_appointment.locator] = [uuid]
 
                 self.db_manager.store_watcher_appointment(uuid, extended_appointment.to_dict())
-                self.db_manager.create_append_locator_map(extended_appointment.locator, uuid)
 
             try:
                 signature = Cryptographer.sign(

--- a/test/teos/unit/mocks.py
+++ b/test/teos/unit/mocks.py
@@ -101,7 +101,6 @@ class AppointmentsDBM:
     def __init__(self):
         self.appointments = dict()
         self.trackers = dict()
-        self.locator_map = dict()
         self.triggered_appointments = set()
         self.last_known_block_watcher = None
         self.last_known_block_responder = None
@@ -140,21 +139,6 @@ class AppointmentsDBM:
 
     def store_responder_tracker(self, uuid, tracker):
         self.trackers[uuid] = tracker
-
-    def load_locator_map(self, locator):
-        return self.locator_map.get(locator)
-
-    def create_append_locator_map(self, locator, uuid):
-        if locator in self.locator_map:
-            self.locator_map[locator].append(uuid)
-        else:
-            self.locator_map[locator] = [uuid]
-
-    def update_locator_map(self, locator, locator_map):
-        self.locator_map[locator] = locator_map
-
-    def delete_locator_map(self, locator):
-        del self.locator_map[locator]
 
     def delete_watcher_appointment(self, uuid):
         del self.appointments[uuid]

--- a/test/teos/unit/test_cleaner.py
+++ b/test/teos/unit/test_cleaner.py
@@ -57,7 +57,6 @@ def set_up_appointments(db_manager, total_appointments):
         locator_uuid_map[locator] = [uuid]
 
         db_manager.store_watcher_appointment(uuid, appointment.to_dict())
-        db_manager.create_append_locator_map(locator, uuid)
 
         # Each locator can have more than one uuid assigned to it.
         if i % 2:
@@ -67,7 +66,6 @@ def set_up_appointments(db_manager, total_appointments):
             locator_uuid_map[locator].append(uuid)
 
             db_manager.store_watcher_appointment(uuid, appointment.to_dict())
-            db_manager.create_append_locator_map(locator, uuid)
 
     return appointments, locator_uuid_map
 
@@ -98,7 +96,6 @@ def set_up_trackers(db_manager, total_trackers):
         tx_tracker_map[penalty_txid] = [uuid]
 
         db_manager.store_responder_tracker(uuid, tracker.to_dict())
-        db_manager.create_append_locator_map(tracker.locator, uuid)
 
         # Each penalty_txid can have more than one uuid assigned to it.
         if i % 2:
@@ -108,7 +105,6 @@ def set_up_trackers(db_manager, total_trackers):
             tx_tracker_map[penalty_txid].append(uuid)
 
             db_manager.store_responder_tracker(uuid, tracker.to_dict())
-            db_manager.create_append_locator_map(tracker.locator, uuid)
 
             # Add them to the Watcher's db too
             db_manager.store_watcher_appointment(uuid, appointment.to_dict())
@@ -158,23 +154,6 @@ def test_delete_appointment_from_db(db_manager):
         # The appointment should have been deleted from the database, but not from memory
         assert uuid in appointments
         assert db_manager.load_watcher_appointment(uuid) is None
-
-
-def test_update_delete_db_locator_map(db_manager):
-    # Tests deleting entries from the locator map
-    appointments, locator_uuid_map = set_up_appointments(db_manager, MAX_ITEMS)
-
-    for uuid, appointment in appointments.items():
-        locator = appointment.get("locator")
-        locator_map_before = db_manager.load_locator_map(locator)
-        Cleaner.update_delete_db_locator_map([uuid], locator, db_manager)
-        locator_map_after = db_manager.load_locator_map(locator)
-
-        # Check that the data is there before but not after cleaning
-        if locator_map_after is None:
-            assert locator_map_before is not None
-        else:
-            assert uuid in locator_map_before and uuid not in locator_map_after
 
 
 def test_delete_appointments(db_manager):

--- a/test/teos/unit/test_cleaner.py
+++ b/test/teos/unit/test_cleaner.py
@@ -177,8 +177,7 @@ def test_update_delete_db_locator_map(db_manager):
             assert uuid in locator_map_before and uuid not in locator_map_after
 
 
-# FIXME: #288
-def test_delete_outdated_appointments(db_manager):
+def test_delete_appointments(db_manager):
     # Tests deleting appointment data both from memory and the database
     for _ in range(ITERATIONS):
         appointments, locator_uuid_map = set_up_appointments(db_manager, MAX_ITEMS)
@@ -193,7 +192,7 @@ def test_delete_outdated_appointments(db_manager):
         assert set(outdated_appointments).issubset(db_appointments.keys())
 
         # Delete
-        Cleaner.delete_outdated_appointments(outdated_appointments, appointments, locator_uuid_map, db_manager)
+        Cleaner.delete_appointments(outdated_appointments, appointments, locator_uuid_map, db_manager)
 
         # Data is not in memory anymore
         all_uuids = list(flatten(locator_uuid_map.values()))
@@ -203,32 +202,6 @@ def test_delete_outdated_appointments(db_manager):
         # And neither is in the database
         db_appointments = db_manager.load_watcher_appointments()
         assert not set(outdated_appointments).issubset(db_appointments.keys())
-
-
-def test_delete_completed_appointments(db_manager):
-    for _ in range(ITERATIONS):
-        appointments, locator_uuid_map = set_up_appointments(db_manager, MAX_ITEMS)
-        completed_appointments = random.sample(list(appointments.keys()), k=ITEMS)
-
-        # Check that the data is there before deletion
-        all_uuids = list(flatten(locator_uuid_map.values()))
-        assert set(completed_appointments).issubset(appointments.keys())
-        assert set(completed_appointments).issubset(all_uuids)
-
-        db_appointments = db_manager.load_watcher_appointments()
-        assert set(completed_appointments).issubset(db_appointments.keys())
-
-        # Delete
-        Cleaner.delete_outdated_appointments(completed_appointments, appointments, locator_uuid_map, db_manager)
-
-        # Data is not in memory anymore
-        all_uuids = list(flatten(locator_uuid_map.values()))
-        assert not set(completed_appointments).issubset(appointments.keys())
-        assert not set(completed_appointments).issubset(all_uuids)
-
-        # And neither is in the database
-        db_appointments = db_manager.load_watcher_appointments()
-        assert not set(completed_appointments).issubset(db_appointments.keys())
 
 
 def test_flag_triggered_appointments(db_manager):


### PR DESCRIPTION
The `locator_uuid_map` of the `Watcher` was being backed up in the database but never being loaded (apart for the updating process) since the map is recreated on bootstrap from the appointment data.

The only benefit of storing the data is to prevent having to recreate the map on bootstrap (which was being done anyway) but it does make the tower to have to read and write data from/to the database way more constantly. 