### PR TITLE
Fix .teos volume path in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,12 @@
 FROM python:3
-VOLUME ["~/.teos"]
+VOLUME ["/root/.teos"]
 WORKDIR /srv
 ADD . /srv/python-teos
 RUN apt-get update && \
     apt-get -y --no-install-recommends install libffi-dev libssl-dev pkg-config libleveldb-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN mkdir ~/.teos && cd python-teos && pip install .
+RUN mkdir /root/.teos && cd python-teos && pip install .
 WORKDIR /srv/python-teos 
 EXPOSE 9814/tcp
 ENTRYPOINT [ "/srv/python-teos/docker/entrypoint.sh" ]


### PR DESCRIPTION
As of containerd 1.4.6, the relative path in the volume will cause the container to not run

https://github.com/containerd/containerd/issues/5547