### PR TITLE
Updates circle-ci bitcoin download link to pull from bitcoincore.org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           name: Install bitcoind (0.20.0)
           command: |
             if [ ! -d "bitcoin" ]; then
-              wget https://bitcoin.org/bin/bitcoin-core-0.20.0/bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
+              wget https://bitcoincore.org/bin/bitcoin-core-0.20.0/bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
               tar -xzf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
               mv bitcoin-0.20.0 bitcoin
             fi


### PR DESCRIPTION
bitcoin.org is getting DDosed recently so tests fail when trying to download the Bitcoin binaries for testing on circle-ci. Update the download link to bitcoincore.org.