### PR TITLE
Catches ReadTimeout in plugin/http

### DIFF
--- a/watchtower-plugin/net/http.py
+++ b/watchtower-plugin/net/http.py
@@ -1,7 +1,6 @@
 import json
 import requests
-from requests import ConnectionError, ConnectTimeout
-from requests.exceptions import MissingSchema, InvalidSchema, InvalidURL
+from requests.exceptions import ConnectionError, ConnectTimeout, ReadTimeout, ReadTimeout, MissingSchema, InvalidSchema, InvalidURL
 
 from common import errors
 from common import constants
@@ -110,10 +109,13 @@ def post_request(data, endpoint, tower_id):
     """
 
     try:
-        return requests.post(url=endpoint, json=data, timeout=5)
+        return requests.post(url=endpoint, json=data, timeout=(6.10, 30))
 
     except ConnectTimeout:
         message = f"Cannot connect to {tower_id}. Connection timeout"
+
+    except ReadTimeout: 
+        message = f"Data cannot be read from {tower_id}. Read timeout"
 
     except ConnectionError:
         message = f"Cannot connect to {tower_id}. Tower cannot be reached"


### PR DESCRIPTION
ReadTimeout was not taking into account when interacting with a tower (the timeout was set but the exception not properly catch). 

Sets different timeouts for connection and read timeouts. The read is significantly higher than the connection to account for slow connections (e.g. tor).