### PR TITLE
Updates ubuntu image use by circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   tests:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202111-02
 
     steps:
       - checkout
@@ -14,8 +14,8 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            pyenv local 3.7.0
-            python -m venv .venv
+            sudo apt-get update && sudo apt-get install -y python3.8-venv
+            python3.8 -m venv .venv
             source .venv/bin/activate
             python -m pip install --upgrade pip
             pip install -r requirements.txt


### PR DESCRIPTION
The previously used image was deprecated, so updating to a newer ubuntu
version. This needs Python3.7 to be manually installed. Leaving it like
this for now, may be updated to reduce build times later on.